### PR TITLE
Separate numbers into integer and float

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -429,7 +429,8 @@ module.exports = grammar({
       $.keyword_identifier,
       $.string,
       $.concatenated_string,
-      $.number,
+      $.integer,
+      $.float,
       $.true,
       $.false,
       $.none,
@@ -737,7 +738,7 @@ module.exports = grammar({
       )
     )),
 
-    number: $ => token(choice(
+    integer: $ => token(choice(
       seq(
         choice('0x', '0X'),
         repeat1(/_?[A-Fa-f0-9]+/),
@@ -754,37 +755,28 @@ module.exports = grammar({
         optional(/[Ll]/)
       ),
       seq(
-        '.',
         repeat1(/[0-9]+_?/),
-        optional(
-          seq(
-            /[eE]/,
-            optional(/[\+-]/)
-          )
-        ),
-        optional(repeat(/[0-9]+_?/)),
-        choice(
-          optional(/[Ll]/), // long numbers
-          optional(/[jJ]/) // complex numbers
-        )
-      ),
-      seq(
-        repeat1(/[0-9]+_?/),
-        optional('.'),
-        optional(repeat(/[0-9]+_?/)),
-        optional(
-          seq(
-            /[eE]/,
-            optional(/[\+-]/)
-          )
-        ),
-        optional(repeat(/[0-9]+_?/)),
         choice(
           optional(/[Ll]/), // long numbers
           optional(/[jJ]/) // complex numbers
         )
       )
     )),
+
+    float: $ => token(
+      seq(
+        choice(
+          seq(repeat(/[0-9]+_?/), '.', repeat(/[0-9]+_?/), optional(/[eE]/), optional(/[\+-]/), repeat(/[0-9]+_?/)),
+          seq(repeat(/[0-9]+_?/), /[eE]/, optional(/[\+-]/), repeat1(/[0-9]+_?/))
+        ),
+        optional(
+          choice(
+            optional(/[Ll]/), // long numbers
+            optional(/[jJ]/) // complex numbers
+          )
+        )
+      )
+    ),
 
     identifier: $ => /[\a_]\w*/,
 

--- a/grammar_test/expressions.txt
+++ b/grammar_test/expressions.txt
@@ -9,9 +9,9 @@ c[4, 5,]
 ---
 
 (module
-  (expression_statement (subscript (identifier) (number)))
-  (expression_statement (subscript (identifier) (number) (number)))
-  (expression_statement (subscript (identifier) (number) (number))))
+  (expression_statement (subscript (identifier) (integer)))
+  (expression_statement (subscript (identifier) (integer) (integer)))
+  (expression_statement (subscript (identifier) (integer) (integer))))
 
 
 =====================================
@@ -31,10 +31,10 @@ c[::]
     (slice)))
   (expression_statement (subscript
     (identifier)
-    (slice (number))))
+    (slice (integer))))
   (expression_statement (subscript
     (identifier)
-    (slice (number) (number))
+    (slice (integer) (integer))
     (ellipsis)))
   (expression_statement (subscript
     (identifier)
@@ -67,12 +67,12 @@ return await i(j, 5)
   (expression_statement
     (await (call
       (identifier)
-      (argument_list (identifier) (number)))))
+      (argument_list (identifier) (integer)))))
   (return_statement
     (expression_list
       (await (call
         (identifier)
-        (argument_list (identifier) (number)))))))
+        (argument_list (identifier) (integer)))))))
 
 =====================================
 Call expressions
@@ -91,7 +91,7 @@ i(j, 5,)
     (argument_list)))
   (expression_statement (call
     (identifier)
-    (argument_list (number))))
+    (argument_list (integer))))
   (expression_statement (call
     (identifier)
     (argument_list
@@ -99,7 +99,7 @@ i(j, 5,)
       (keyword_argument (identifier) (identifier)))))
   (expression_statement (call
     (identifier)
-    (argument_list (identifier) (number)))))
+    (argument_list (identifier) (integer)))))
 
 =====================================
 Print used as an identifier
@@ -227,8 +227,8 @@ a + b * c ** d - e / 5
             (identifier))))
       (binary_operator
         (identifier)
-        (number))))
-  (expression_statement (unary_operator (number)))
+        (integer))))
+  (expression_statement (unary_operator (integer)))
   (expression_statement (unary_operator (identifier)))
   (expression_statement (unary_operator (identifier))))
 
@@ -311,22 +311,22 @@ a[b] = c = d
       (expression_list
         (identifier))
       (expression_list
-        (number))))
+        (integer))))
   (expression_statement
     (assignment
       (expression_list
         (identifier)
         (identifier))
       (expression_list
-        (number)
-        (number))))
+        (integer)
+        (integer))))
   (expression_statement
     (assignment
       (expression_list
         (identifier))
       (expression_list
-        (number)
-        (number))))
+        (integer)
+        (integer))))
   (expression_statement
     (assignment
       (expression_list
@@ -349,15 +349,15 @@ c //= 1
   (expression_statement
     (augmented_assignment
       (expression_list (identifier))
-      (expression_list (number))))
+      (expression_list (integer))))
   (expression_statement
     (augmented_assignment
       (expression_list (identifier))
-      (expression_list (number))))
+      (expression_list (integer))))
   (expression_statement
     (augmented_assignment
       (expression_list (identifier))
-      (expression_list (number)))))
+      (expression_list (integer)))))
 
 ====================================================
 Yield expressions
@@ -372,11 +372,11 @@ yield from a
 
 (module
   (expression_statement (yield))
-  (expression_statement (yield (expression_list (number))))
+  (expression_statement (yield (expression_list (integer))))
   (expression_statement
     (assignment
       (expression_list (identifier))
-      (yield (expression_list (number)))))
+      (yield (expression_list (integer)))))
   (expression_statement
     (yield (identifier))))
 
@@ -447,5 +447,5 @@ slice(1,1,1) if a else d
   (expression_statement
     (conditional_expression (call (identifier) (argument_list)) (identifier) (identifier)))
   (expression_statement (conditional_expression
-    (call (identifier) (argument_list (number) (number) (number)))
+    (call (identifier) (argument_list (integer) (integer) (integer)))
 		(identifier) (identifier))))

--- a/grammar_test/literals.txt
+++ b/grammar_test/literals.txt
@@ -1,60 +1,70 @@
 =====================================
-Numbers
+Integers
 =====================================
 
--.6
 -1
-123.4123
 0xDEAD
 0XDEAD
 1j
 -1j
-123.123J
 0o123
 0O123
 0b001
 0B001
 1_1
-1_1.3_1
-1_1.
-.1_1
 0B1_1
 0O1_1
+0L
+
+---
+
+(module
+  (expression_statement (unary_operator (integer)))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (unary_operator (integer)))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer))
+  (expression_statement (integer)))
+
+=====================================
+Floats
+=====================================
+
+-.6_6
++.1_1
+123.4123
+123.123J
+1_1.3_1
+1_1.
 1e+3_4j
 .3e1_4
-0L
 1_0.l
 .1l
 
 ---
 
 (module
-  (expression_statement (unary_operator (number)))
-  (expression_statement (unary_operator (number)))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (unary_operator (number)))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number)))
+  (expression_statement (unary_operator (float)))
+  (expression_statement (unary_operator (float)))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float)))
+
 
 =====================================
-Scientific Notation
+Scientific Notation Floats
 =====================================
 
 1e322
@@ -67,12 +77,12 @@ Scientific Notation
 ---
 
 (module
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (number))
-  (expression_statement (unary_operator (number))))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (float))
+  (expression_statement (unary_operator (float))))
 
 =====================================
 Strings
@@ -239,8 +249,8 @@ Dictionaries
 
 (module
   (expression_statement (dictionary
-    (pair (identifier) (number))
-    (pair (identifier) (number))))
+    (pair (identifier) (integer))
+    (pair (identifier) (integer))))
   (expression_statement (dictionary)))
 
 =====================================

--- a/grammar_test/statements.txt
+++ b/grammar_test/statements.txt
@@ -53,10 +53,10 @@ print 0 or 1
   (print_statement (identifier))
   (print_statement (identifier) (identifier))
   (print_statement
-    (boolean_operator (number) (number))
-    (boolean_operator (number) (number)))
+    (boolean_operator (integer) (integer))
+    (boolean_operator (integer) (integer)))
   (print_statement
-    (boolean_operator (number) (number))))
+    (boolean_operator (integer) (integer))))
 
 =====================================
 Print statements with redirection
@@ -98,8 +98,8 @@ b + c
 (module
   (expression_statement (identifier))
   (expression_statement (binary_operator (identifier) (identifier)))
-  (expression_statement (number) (number) (number))
-  (expression_statement (number) (number) (number)))
+  (expression_statement (integer) (integer) (integer))
+  (expression_statement (integer) (integer) (integer)))
 
 =====================================
 Delete statements
@@ -111,8 +111,8 @@ del a[1], b[2]
 
 (module
   (delete_statement (expression_list
-    (subscript (identifier) (number))
-    (subscript (identifier) (number)))))
+    (subscript (identifier) (integer))
+    (subscript (identifier) (integer)))))
 
 =====================================
 Control-flow statements
@@ -278,7 +278,7 @@ for x, in [(1,), (2,), (3,)]:
       (print_statement (identifier))))
   (for_statement
     (variables (identifier))
-    (expression_list (list (tuple (number)) (tuple (number)) (tuple (number))))
+    (expression_list (list (tuple (integer)) (tuple (integer)) (tuple (integer))))
     (expression_statement (identifier))))
 
 =====================================
@@ -605,11 +605,11 @@ class C:
         (decorator
           (dotted_name (identifier))
           (argument_list
-            (number)))
+            (integer)))
         (decorator
           (dotted_name (identifier))
           (argument_list
-            (number) (number)))
+            (integer) (integer)))
         (decorator
           (dotted_name (identifier))
           (argument_list
@@ -625,7 +625,7 @@ class C:
         (decorator
           (dotted_name (identifier))
           (argument_list
-            (number)
+            (integer)
             (keyword_argument (identifier) (true))
             (list_splat_argument (identifier))
             (dictionary_splat_argument (identifier))))

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1864,7 +1864,11 @@
         },
         {
           "type": "SYMBOL",
-          "name": "number"
+          "name": "integer"
+        },
+        {
+          "type": "SYMBOL",
+          "name": "float"
         },
         {
           "type": "SYMBOL",
@@ -3602,7 +3606,7 @@
         ]
       }
     },
-    "number": {
+    "integer": {
       "type": "TOKEN",
       "content": {
         "type": "CHOICE",
@@ -3722,59 +3726,11 @@
             "type": "SEQ",
             "members": [
               {
-                "type": "STRING",
-                "value": "."
-              },
-              {
                 "type": "REPEAT1",
                 "content": {
                   "type": "PATTERN",
                   "value": "[0-9]+_?"
                 }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "SEQ",
-                    "members": [
-                      {
-                        "type": "PATTERN",
-                        "value": "[eE]"
-                      },
-                      {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "[\\+-]"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
-                      }
-                    ]
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "REPEAT",
-                    "content": {
-                      "type": "PATTERN",
-                      "value": "[0-9]+_?"
-                    }
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
               },
               {
                 "type": "CHOICE",
@@ -3806,31 +3762,20 @@
                 ]
               }
             ]
-          },
+          }
+        ]
+      }
+    },
+    "float": {
+      "type": "TOKEN",
+      "content": {
+        "type": "SEQ",
+        "members": [
           {
-            "type": "SEQ",
+            "type": "CHOICE",
             "members": [
               {
-                "type": "REPEAT1",
-                "content": {
-                  "type": "PATTERN",
-                  "value": "[0-9]+_?"
-                }
-              },
-              {
-                "type": "CHOICE",
-                "members": [
-                  {
-                    "type": "STRING",
-                    "value": "."
-                  },
-                  {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
+                "type": "SEQ",
                 "members": [
                   {
                     "type": "REPEAT",
@@ -3840,41 +3785,51 @@
                     }
                   },
                   {
-                    "type": "BLANK"
-                  }
-                ]
-              },
-              {
-                "type": "CHOICE",
-                "members": [
+                    "type": "STRING",
+                    "value": "."
+                  },
                   {
-                    "type": "SEQ",
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[0-9]+_?"
+                    }
+                  },
+                  {
+                    "type": "CHOICE",
                     "members": [
                       {
                         "type": "PATTERN",
                         "value": "[eE]"
                       },
                       {
-                        "type": "CHOICE",
-                        "members": [
-                          {
-                            "type": "PATTERN",
-                            "value": "[\\+-]"
-                          },
-                          {
-                            "type": "BLANK"
-                          }
-                        ]
+                        "type": "BLANK"
                       }
                     ]
                   },
                   {
-                    "type": "BLANK"
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\+-]"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "REPEAT",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[0-9]+_?"
+                    }
                   }
                 ]
               },
               {
-                "type": "CHOICE",
+                "type": "SEQ",
                 "members": [
                   {
                     "type": "REPEAT",
@@ -3884,10 +3839,35 @@
                     }
                   },
                   {
-                    "type": "BLANK"
+                    "type": "PATTERN",
+                    "value": "[eE]"
+                  },
+                  {
+                    "type": "CHOICE",
+                    "members": [
+                      {
+                        "type": "PATTERN",
+                        "value": "[\\+-]"
+                      },
+                      {
+                        "type": "BLANK"
+                      }
+                    ]
+                  },
+                  {
+                    "type": "REPEAT1",
+                    "content": {
+                      "type": "PATTERN",
+                      "value": "[0-9]+_?"
+                    }
                   }
                 ]
-              },
+              }
+            ]
+          },
+          {
+            "type": "CHOICE",
+            "members": [
               {
                 "type": "CHOICE",
                 "members": [
@@ -3916,6 +3896,9 @@
                     ]
                   }
                 ]
+              },
+              {
+                "type": "BLANK"
               }
             ]
           }


### PR DESCRIPTION
This allows us to produce number literals as `float` or `integer`.

cc/ @maxbrunsfeld 