### PR TITLE
Add named lambda_parameters rule

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -384,39 +384,38 @@ yield from a
 lambdas
 ====================================================
 
-A = lambda b, c: d("e" % f)
-B = lambda: True
-C = lambda a, b = c, *d, **e: a
-D = lambda (a,b): (a, b)
+lambda b, c: d("e" % f)
+lambda: True
+lambda a, b = c, *d, **e: a
+lambda (a,b): (a, b)
 
 ---
 
 (module
-  (expression_statement (assignment
-    (expression_list (identifier))
-    (expression_list (lambda
-      (identifier)
-      (identifier)
+  (expression_statement
+    (lambda
+      (lambda_parameters
+        (identifier)
+        (identifier))
       (call
         (identifier)
         (argument_list
-          (binary_operator (string) (identifier))))))))
-  (expression_statement (assignment
-    (expression_list (identifier))
-    (expression_list (lambda (true)))))
-  (expression_statement (assignment
-    (expression_list (identifier))
-    (expression_list (lambda
-      (identifier)
-      (default_parameter (identifier) (identifier))
-      (list_splat_parameter (identifier))
-      (dictionary_splat_parameter (identifier))
-      (identifier)))))
-  (expression_statement (assignment
-    (expression_list (identifier))
-    (expression_list (lambda
-      (tuple (identifier) (identifier))
-      (tuple (identifier) (identifier)))))))
+          (binary_operator (string) (identifier))))))
+  (expression_statement
+    (lambda (true)))
+  (expression_statement
+    (lambda
+      (lambda_parameters
+        (identifier)
+        (default_parameter (identifier) (identifier))
+        (list_splat_parameter (identifier))
+        (dictionary_splat_parameter (identifier)))
+      (identifier)))
+  (expression_statement
+    (lambda
+      (lambda_parameters
+        (tuple (identifier) (identifier)))
+      (tuple (identifier) (identifier)))))
 
 =====================================
 Conditional if expressions

--- a/grammar.js
+++ b/grammar.js
@@ -287,6 +287,8 @@ module.exports = grammar({
       ')'
     ),
 
+    lambda_parameters: $ => $._parameters,
+
     _parameters: $ => seq(
       commaSep1(choice(
         $.identifier,
@@ -501,7 +503,7 @@ module.exports = grammar({
 
     lambda: $ => seq(
       'lambda',
-      optional($._parameters),
+      optional($.lambda_parameters),
       ':',
       $._expression
     ),

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -1107,6 +1107,10 @@
         }
       ]
     },
+    "lambda_parameters": {
+      "type": "SYMBOL",
+      "name": "_parameters"
+    },
     "_parameters": {
       "type": "SEQ",
       "members": [
@@ -2418,7 +2422,7 @@
           "members": [
             {
               "type": "SYMBOL",
-              "name": "_parameters"
+              "name": "lambda_parameters"
             },
             {
               "type": "BLANK"


### PR DESCRIPTION
This differentiates lambda parameters from the rest of the expressions in a lambda body. @maxbrunsfeld the motivation behind this is to make it easier in the shape of the tree to determine where the body of the lambda starts. This isn't so much of a problem for function calls or function definitions, because those parameters include `(` and `)`, but lambda parameters do not use `()`.

I also simplified the test for lambdas, as the assignment was unnecessary.

