### PR TITLE
Update to latest tree-sitter API

### DIFF
--- a/corpus/expressions.txt
+++ b/corpus/expressions.txt
@@ -124,30 +124,30 @@ def print():
 
 (module
   (expression_statement (call
-    (keyword_identifier)
+    (identifier)
     (argument_list
       (identifier)
       (keyword_argument (identifier) (identifier)))))
   (expression_statement (call
-    (keyword_identifier)
+    (identifier)
     (argument_list
       (identifier)
       (list_splat_argument (identifier)))))
   (expression_statement (call
-    (keyword_identifier)
+    (identifier)
     (argument_list
       (list_splat_argument (identifier))
       (dictionary_splat_argument (identifier)))))
   (expression_statement (call
     (identifier)
-    (argument_list (keyword_identifier))))
+    (argument_list (identifier))))
   (function_definition
     (identifier)
-    (parameters (keyword_identifier))
+    (parameters (identifier))
     (expression_statement (identifier)))
   (function_definition
     (identifier)
-    (parameters (default_parameter (identifier) (keyword_identifier)))
+    (parameters (default_parameter (identifier) (identifier)))
     (expression_statement (identifier)))
   (function_definition
     (identifier)
@@ -175,13 +175,13 @@ exec("""exec _code_ in _globs_, _locs_""")
 (module
   (expression_statement
     (call
-      (keyword_identifier)
+      (identifier)
       (argument_list
         (string)
         (dictionary (pair (string) (none)))
         (identifier))))
   (expression_statement
-    (call (keyword_identifier) (argument_list (string)))))
+    (call (identifier) (argument_list (string)))))
 
 =====================================
 Calls with splats

--- a/grammar.js
+++ b/grammar.js
@@ -34,15 +34,26 @@ module.exports = grammar({
   ],
 
   conflicts: $ => [
-    [$.keyword_identifier, $.print_statement],
-    [$.keyword_identifier, $.exec_statement]
+    [$._primary_expression, $.print_statement],
+    [$._primary_expression, $.exec_statement]
+  ],
+
+  inline: $ => [
+    $._simple_statement,
+    $._compound_statement,
+    $.keyword_identifier,
   ],
 
   rules: {
     module: $ => repeat($._statement),
 
     _statement: $ => choice(
-      seq($._simple_statement, optional(repeat(seq($._semicolon, $._simple_statement))), optional($._semicolon), repeat1($._newline)),
+      seq(
+        $._simple_statement,
+        optional(repeat(seq($._semicolon, $._simple_statement))),
+        optional($._semicolon),
+        $._newline
+      ),
       $._compound_statement
     ),
 
@@ -64,8 +75,6 @@ module.exports = grammar({
       $.nonlocal_statement,
       $.exec_statement
     ),
-
-    keyword_identifier: $ => choice('print', 'exec'),
 
     import_statement: $ => seq(
       'import',
@@ -782,9 +791,10 @@ module.exports = grammar({
 
     identifier: $ => /[\a_]\w*/,
 
+    keyword_identifier: $ => rename(choice('print', 'exec'), 'identifier'),
+
     true: $ => 'True',
     false: $ => 'False',
-
     none: $ => 'None',
 
     await: $ => seq(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.4.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.5.3"
+    "tree-sitter-cli": "^0.6.5"
   },
   "scripts": {
     "build": "tree-sitter generate && node-gyp build",

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -55,11 +55,8 @@
               ]
             },
             {
-              "type": "REPEAT1",
-              "content": {
-                "type": "SYMBOL",
-                "name": "_newline"
-              }
+              "type": "SYMBOL",
+              "name": "_newline"
             }
           ]
         },
@@ -127,19 +124,6 @@
         {
           "type": "SYMBOL",
           "name": "exec_statement"
-        }
-      ]
-    },
-    "keyword_identifier": {
-      "type": "CHOICE",
-      "members": [
-        {
-          "type": "STRING",
-          "value": "print"
-        },
-        {
-          "type": "STRING",
-          "value": "exec"
         }
       ]
     },
@@ -3913,6 +3897,23 @@
       "type": "PATTERN",
       "value": "[\\a_]\\w*"
     },
+    "keyword_identifier": {
+      "type": "RENAME",
+      "content": {
+        "type": "CHOICE",
+        "members": [
+          {
+            "type": "STRING",
+            "value": "print"
+          },
+          {
+            "type": "STRING",
+            "value": "exec"
+          }
+        ]
+      },
+      "value": "identifier"
+    },
     "true": {
       "type": "STRING",
       "value": "True"
@@ -3971,11 +3972,11 @@
   ],
   "conflicts": [
     [
-      "keyword_identifier",
+      "_primary_expression",
       "print_statement"
     ],
     [
-      "keyword_identifier",
+      "_primary_expression",
       "exec_statement"
     ]
   ],
@@ -3992,5 +3993,10 @@
       "type": "SYMBOL",
       "name": "_dedent"
     }
+  ],
+  "inline": [
+    "_simple_statement",
+    "_compound_statement",
+    "keyword_identifier"
   ]
 }

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -58,12 +58,18 @@ struct Scanner {
     }
 
     if (lexer->lookahead == 0) {
-      if (valid_symbols[DEDENT]) {
+      if (valid_symbols[DEDENT] && indent_length_stack.size() > 1) {
+        indent_length_stack.pop_back();
         lexer->result_symbol = DEDENT;
-      } else {
-        lexer->result_symbol = NEWLINE;
+        return true;
       }
-      return true;
+
+      if (valid_symbols[NEWLINE]) {
+        lexer->result_symbol = NEWLINE;
+        return true;
+      }
+
+      return false;
     }
 
     if (lexer->lookahead != '\n') return false;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,10 +1,6 @@
 #include <tree_sitter/parser.h>
 #include <vector>
 
-#ifndef UINT8_MAX
-#define UINT8_MAX (255)
-#endif
-
 namespace {
 
 using std::vector;
@@ -16,45 +12,33 @@ enum TokenType {
 };
 
 struct Scanner {
-  Scanner() : queued_dedent_count(0) {
-    indent_length_stack.push_back(0);
+  Scanner() {
+    deserialize(NULL, 0);
   }
 
-  void reset() {
+  unsigned serialize(char *buffer) {
+    size_t i = 0;
+    buffer[i++] = queued_dedent_count;
+
+    vector<uint16_t>::iterator
+      iter = indent_length_stack.begin() + 1,
+      end = indent_length_stack.end();
+    for (; iter != end && i < TREE_SITTER_SERIALIZATION_BUFFER_SIZE; ++iter) {
+      buffer[i++] = *iter;
+    }
+
+    return i;
+  }
+
+  void deserialize(const char *buffer, unsigned length) {
     queued_dedent_count = 0;
     indent_length_stack.clear();
     indent_length_stack.push_back(0);
-  }
 
-  bool serialize(TSExternalTokenState state) {
-    size_t i = 0;
-
-    if (queued_dedent_count > UINT8_MAX) return false;
-    state[i++] = queued_dedent_count;
-
-    if (indent_length_stack.size() > 14) return false;
-    state[i++] = indent_length_stack.size();
-
-    vector<uint16_t>::iterator iter = indent_length_stack.begin(),
-      end = indent_length_stack.end();
-
-    for (; iter != end; ++iter) {
-      if (*iter > UINT8_MAX) return false;
-      state[i++] = *iter;
-    }
-
-    return true;
-  }
-
-  void deserialize(TSExternalTokenState state) {
-    size_t i = 0;
-
-    queued_dedent_count = state[i++];
-
-    size_t indent_length_stack_size = state[i++];
-    indent_length_stack.clear();
-    for (size_t j = 0; j < indent_length_stack_size; j++) {
-      indent_length_stack.push_back(state[i++]);
+    if (length > 0) {
+      size_t i = 0;
+      queued_dedent_count = buffer[i++];
+      while (i < length) indent_length_stack.push_back(buffer[i++]);
     }
   }
 
@@ -141,19 +125,14 @@ bool tree_sitter_python_external_scanner_scan(void *payload, TSLexer *lexer,
   return scanner->scan(lexer, valid_symbols);
 }
 
-void tree_sitter_python_external_scanner_reset(void *payload) {
+unsigned tree_sitter_python_external_scanner_serialize(void *payload, char *buffer) {
   Scanner *scanner = static_cast<Scanner *>(payload);
-  scanner->reset();
+  return scanner->serialize(buffer);
 }
 
-bool tree_sitter_python_external_scanner_serialize(void *payload, TSExternalTokenState state) {
+void tree_sitter_python_external_scanner_deserialize(void *payload, const char *buffer, unsigned length) {
   Scanner *scanner = static_cast<Scanner *>(payload);
-  return scanner->serialize(state);
-}
-
-void tree_sitter_python_external_scanner_deserialize(void *payload, TSExternalTokenState state) {
-  Scanner *scanner = static_cast<Scanner *>(payload);
-  scanner->deserialize(state);
+  scanner->deserialize(buffer, length);
 }
 
 void tree_sitter_python_external_scanner_destroy(void *payload) {


### PR DESCRIPTION
This updates the external scanner to use the new serialization API. I also have gotten rid of the `keyword_identifier` rule using the new contextual aliases feature.