### PR TITLE
Add parse-examples script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ package-lock.json
 node_modules
 build
 *.log
+/examples/numpy

--- a/script/known_failures.txt
+++ b/script/known_failures.txt
@@ -1,0 +1,4 @@
+examples/numpy/numpy/distutils/conv_template.py
+examples/numpy/numpy/distutils/ccompiler.py
+examples/numpy/numpy/distutils/from_template.py
+examples/numpy/numpy/f2py/crackfortran.py

--- a/script/parse-examples
+++ b/script/parse-examples
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")/.."
+
+# Clone example repo and check out a known sha
+repo=examples/numpy
+if [ ! -d "$repo" ]; then
+  git clone https://github.com/numpy/numpy "$repo"
+else
+  pushd "$repo" && git fetch
+  git reset --hard 058851c5cfc98f50f11237b1c13d77cfd1f40475
+  popd
+fi
+
+tree-sitter parse examples/*.py -qt
+
+# TODO: Fix known issues in known_failures.txt
+known_failures=$(cat script/known_failures.txt)
+examples_to_parse=$(
+  for example in $(find "$repo" -name '*.py'); do
+    if [[ ! $known_failures == *$example* ]]; then
+      echo $example
+    fi
+  done
+)
+
+echo $examples_to_parse | xargs -n 5000 tree-sitter parse -q
+
+skipped=$( echo $known_failures | wc -w )
+parsed=$( echo $examples_to_parse | wc -w )
+total=$((parsed+skipped))
+percent=$(bc -l <<< "100*$parsed/$total")
+
+printf "Successfully parsed %.2f%% of $repo (%d of %d files)\n" $percent $parsed $total


### PR DESCRIPTION
Similar to the other tree-sitter language grammars, this introduces a small script to parse examples and print coverage stats.