### PR TITLE
\u, \U and \N are not escape sequences in bytes string

### DIFF
--- a/corpus/literals.txt
+++ b/corpus/literals.txt
@@ -98,6 +98,7 @@ B"sup"
 "/"
 "multiline \
 string"
+b"\x12\u12\U12\x13\N{WINKING FACE}"
 
 ---
 
@@ -110,7 +111,8 @@ string"
   (expression_statement (string))
   (expression_statement (string (escape_sequence)))
   (expression_statement (string))
-  (expression_statement (string (escape_sequence))))
+  (expression_statement (string (escape_sequence)))
+  (expression_statement (string (escape_sequence) (escape_sequence))))
 
 =====================================
 Raw strings

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "nan": "^2.4.0"
   },
   "devDependencies": {
-    "tree-sitter-cli": "^0.15.5",
+    "tree-sitter-cli": "^0.15.12",
     "tree-sitter-highlight-schema": "^0.1.1"
   },
   "scripts": {


### PR DESCRIPTION
For reference:
https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals