### PR TITLE
Properly generate node-types with tree-sitter fix for aliases

### DIFF
--- a/src/node-types.json
+++ b/src/node-types.json
@@ -1762,6 +1762,14 @@
           "named": true
         },
         {
+          "type": "list_splat",
+          "named": true
+        },
+        {
+          "type": "parenthesized_expression",
+          "named": true
+        },
+        {
           "type": "yield",
           "named": true
         }


### PR DESCRIPTION
This is the diff for node-types.json using https://github.com/tree-sitter/tree-sitter/pull/489