### PR TITLE
Fixing wrong operators to keywords

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -84,14 +84,14 @@
   ">>"
   "|"
   "~"
+] @operator
+
+[
   "and"
   "in"
   "is"
   "not"
   "or"
-] @operator
-
-[
   "as"
   "assert"
   "async"


### PR DESCRIPTION
This PR makes "and" "in" "is" "not" "or" keywords instead of operators
According to the [official python docs](https://docs.python.org/3/reference/lexical_analysis.html#keywords)