### PR TITLE
Fixing keywords operators

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -84,14 +84,14 @@
   ">>"
   "|"
   "~"
+] @operator
+
+[
   "and"
   "in"
   "is"
   "not"
   "or"
-] @operator
-
-[
   "as"
   "assert"
   "async"

--- a/test/highlight/keywords.py
+++ b/test/highlight/keywords.py
@@ -17,7 +17,7 @@ raise e
 for i in foo():
 # <- keyword
 #   ^ variable
-#     ^ operator
+#     ^ keyword
 #        ^ function
     continue
     # <- keyword
@@ -25,6 +25,6 @@ for i in foo():
     # <- keyword
 
 a and b or c
-# ^ operator
+# ^ keyword
 #     ^ variable
-#       ^ operator
+#       ^ keyword


### PR DESCRIPTION
This PR makes "and" "in" "is" "not" "or" keywords instead of operators and updates existing highlighting tests

According to [python docs](https://docs.python.org/3/reference/lexical_analysis.html#keywords)