### PR TITLE
Add Rust package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
+Cargo.lock
 package-lock.json
 node_modules
 build
 *.log
 /examples/*/
+/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,32 @@
+[package]
+name = "tree-sitter-python"
+description = "Python grammar for the tree-sitter parsing library"
+version = "0.16.1"
+authors = [
+    "Max Brunsfeld <maxbrunsfeld@gmail.com>",
+    "Douglas Creager <dcreager@dcreager.net>",
+]
+license = "MIT"
+keywords = ["incremental", "parsing", "python"]
+categories = ["parsing", "text-editors"]
+repository = "https://github.com/tree-sitter/tree-sitter-python"
+edition = "2018"
+
+build = "bindings/rust/build.rs"
+include = [
+  "bindings/rust/*",
+  "grammar.js",
+  "src/*",
+]
+
+[lib]
+path = "bindings/rust/lib.rs"
+
+[dependencies]
+tree-sitter = "0.17"
+
+[build-dependencies]
+cc = "1.0"
+
+[dev-dependencies]
+indoc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,3 @@ tree-sitter = "0.17"
 
 [build-dependencies]
 cc = "1.0"
-
-[dev-dependencies]
-indoc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Douglas Creager <dcreager@dcreager.net>",
 ]
 license = "MIT"
+readme = "bindings/rust/README.md"
 keywords = ["incremental", "parsing", "python"]
 categories = ["parsing", "text-editors"]
 repository = "https://github.com/tree-sitter/tree-sitter-python"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -1,0 +1,34 @@
+# tree-sitter-python
+
+This crate provides a Python grammar for the [tree-sitter][] parsing library.
+To use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
+file.  (Note that you will probably also need to depend on `tree-sitter` to use
+the parsed result in any useful way.)
+
+``` toml
+[dependencies]
+tree-sitter = "0.17"
+tree-sitter-python = "0.16"
+```
+
+Typically, you will use the [parser][] function to create a tree-sitter
+[Parser][] that is configured to use this grammar, and then use the parser to
+parse some code:
+
+``` rust
+let code = indoc! {"
+    def double(x):
+        return x * 2
+"};
+let mut parser = tree_sitter_python::parser();
+let parsed = parser.parse(code, None);
+```
+
+If you have any questions, please reach out to us in the [tree-sitter
+discussions] page.
+
+[Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+[parser]: fn.parser.html
+[tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -12,9 +12,9 @@ tree-sitter = "0.17"
 tree-sitter-python = "0.16"
 ```
 
-Typically, you will use the [parser func][] function to create a tree-sitter
-[Parser][] that is configured to use this grammar, and then use the parser to
-parse some code:
+Typically, you will use the [parser][parser func] function to create a
+tree-sitter [Parser][] that is configured to use this grammar, and then use the
+parser to parse some code:
 
 ``` rust
 let code = indoc! {"

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -2,8 +2,9 @@
 
 This crate provides a Python grammar for the [tree-sitter][] parsing library.
 To use this crate, add it to the `[dependencies]` section of your `Cargo.toml`
-file.  (Note that you will probably also need to depend on `tree-sitter` to use
-the parsed result in any useful way.)
+file.  (Note that you will probably also need to depend on the
+[`tree-sitter`][tree-sitter crate] crate to use the parsed result in any useful
+way.)
 
 ``` toml
 [dependencies]
@@ -31,4 +32,5 @@ discussions] page.
 [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 [parser func]: https://docs.rs/tree-sitter-python/*/tree_sitter_python/fn.parser.html
 [tree-sitter]: https://tree-sitter.github.io/
+[tree-sitter crate]: https://crates.io/crates/tree-sitter
 [tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -11,7 +11,7 @@ tree-sitter = "0.17"
 tree-sitter-python = "0.16"
 ```
 
-Typically, you will use the [parser][] function to create a tree-sitter
+Typically, you will use the [parser func][] function to create a tree-sitter
 [Parser][] that is configured to use this grammar, and then use the parser to
 parse some code:
 
@@ -29,6 +29,6 @@ discussions] page.
 
 [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
-[parser]: fn.parser.html
+[parser func]: https://docs.rs/tree-sitter-python/*/tree_sitter_python/fn.parser.html
 [tree-sitter]: https://tree-sitter.github.io/
 [tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -12,9 +12,8 @@ tree-sitter = "0.17"
 tree-sitter-python = "0.16"
 ```
 
-Typically, you will use the [parser][parser func] function to create a
-tree-sitter [Parser][] that is configured to use this grammar, and then use the
-parser to parse some code:
+Typically, you will use the [language][language func] function to add this
+grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
 
 ``` rust
 let code = indoc! {"
@@ -29,8 +28,8 @@ If you have any questions, please reach out to us in the [tree-sitter
 discussions] page.
 
 [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+[language func]: https://docs.rs/tree-sitter-python/*/tree_sitter_python/fn.language.html
 [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
-[parser func]: https://docs.rs/tree-sitter-python/*/tree_sitter_python/fn.parser.html
 [tree-sitter]: https://tree-sitter.github.io/
 [tree-sitter crate]: https://crates.io/crates/tree-sitter
 [tree-sitter discussions]: https://github.com/tree-sitter/tree-sitter/discussions

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -1,0 +1,28 @@
+use std::path::Path;
+extern crate cc;
+
+fn main() {
+    let src_dir = Path::new("src");
+
+    let mut c_config = cc::Build::new();
+    c_config.include(&src_dir);
+    c_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable")
+        .flag_if_supported("-Wno-trigraphs");
+    let parser_path = src_dir.join("parser.c");
+    c_config.file(&parser_path);
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
+    c_config.compile("parser");
+
+    let mut cpp_config = cc::Build::new();
+    cpp_config.cpp(true);
+    cpp_config.include(&src_dir);
+    cpp_config
+        .flag_if_supported("-Wno-unused-parameter")
+        .flag_if_supported("-Wno-unused-but-set-variable");
+    let scanner_path = src_dir.join("scanner.cc");
+    cpp_config.file(&scanner_path);
+    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
+    cpp_config.compile("scanner");
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -10,11 +10,10 @@
 //! that is configured to use this grammar, and then use the parser to parse some code:
 //!
 //! ```
-//! # use indoc::indoc;
-//! let code = indoc! {"
+//! let code = r#"
 //!     def double(x):
 //!         return x * 2
-//! "};
+//! "#;
 //! let mut parser = tree_sitter_python::parser();
 //! let parsed = parser.parse(code, None);
 //! # assert!(parsed.is_some());

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -10,11 +10,14 @@
 //! that is configured to use this grammar, and then use the parser to parse some code:
 //!
 //! ```
+//! use tree_sitter::Parser;
+//!
 //! let code = r#"
 //!     def double(x):
 //!         return x * 2
 //! "#;
-//! let mut parser = tree_sitter_python::parser();
+//! let mut parser = Parser::new();
+//! parser.set_language(tree_sitter_python::language()).expect("Error loading Python grammar");
 //! let parsed = parser.parse(code, None);
 //! # assert!(parsed.is_some());
 //! ```
@@ -25,21 +28,9 @@
 //! [tree-sitter]: https://tree-sitter.github.io/
 
 use tree_sitter::Language;
-use tree_sitter::Parser;
 
 extern "C" {
     fn tree_sitter_python() -> Language;
-}
-
-/// Returns a new tree-sitter [Parser][] preconfigured to parse Python code.
-///
-/// [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
-pub fn parser() -> Parser {
-    let mut parser = Parser::new();
-    parser
-        .set_language(language())
-        .expect("Error installing Python grammar");
-    parser
 }
 
 /// Returns the tree-sitter [Language][] for this grammar.
@@ -61,6 +52,9 @@ pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 mod tests {
     #[test]
     fn can_load_grammar() {
-        let _parser = super::parser();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(super::language())
+            .expect("Error loading Python grammar");
     }
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -1,0 +1,67 @@
+// -*- coding: utf-8 -*-
+// ------------------------------------------------------------------------------------------------
+// Copyright © 2020, tree-sitter-python authors.
+// See the LICENSE file in this repo for license details.
+// ------------------------------------------------------------------------------------------------
+
+//! This crate provides a Python grammar for the [tree-sitter][] parsing library.
+//!
+//! Typically, you will use the [parser][] function to create a tree-sitter [Parser][] that is
+//! configured to use this grammar, and then use the parser to parse some code:
+//!
+//! ```
+//! # use indoc::indoc;
+//! let code = indoc! {"
+//!     def double(x):
+//!         return x * 2
+//! "};
+//! let mut parser = tree_sitter_python::parser();
+//! let parsed = parser.parse(code, None);
+//! # assert!(parsed.is_some());
+//! ```
+//!
+//! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+//! [parser]: fn.parser.html
+//! [tree-sitter]: https://tree-sitter.github.io/
+
+use tree_sitter::Language;
+use tree_sitter::Parser;
+
+extern "C" {
+    fn tree_sitter_python() -> Language;
+}
+
+/// Returns a new tree-sitter [Parser][] preconfigured to parse Python code.
+///
+/// [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
+pub fn parser() -> Parser {
+    let mut parser = Parser::new();
+    parser
+        .set_language(language())
+        .expect("Error installing Python grammar");
+    parser
+}
+
+/// Returns the tree-sitter [Language][] for this grammar.
+///
+/// [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+pub fn language() -> Language {
+    unsafe { tree_sitter_python() }
+}
+
+/// The source of the Python tree-sitter grammar description.
+pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
+
+/// The content of the [`node-types.json`][] file for this grammar.
+///
+/// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
+pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn can_load_grammar() {
+        let _parser = super::parser();
+    }
+}

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,8 +6,8 @@
 
 //! This crate provides a Python grammar for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [parser][parser func] function to create a tree-sitter [Parser][]
-//! that is configured to use this grammar, and then use the parser to parse some code:
+//! Typically, you will use the [language][language func] function to add this grammar to a
+//! tree-sitter [Parser][], and then use the parser to parse some code:
 //!
 //! ```
 //! use tree_sitter::Parser;
@@ -23,8 +23,8 @@
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
+//! [language func]: fn.language.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
-//! [parser func]: fn.parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
 use tree_sitter::Language;

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,8 +6,8 @@
 
 //! This crate provides a Python grammar for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [parser func][] function to create a tree-sitter [Parser][] that is
-//! configured to use this grammar, and then use the parser to parse some code:
+//! Typically, you will use the [parser][parser func] function to create a tree-sitter [Parser][]
+//! that is configured to use this grammar, and then use the parser to parse some code:
 //!
 //! ```
 //! # use indoc::indoc;

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -6,7 +6,7 @@
 
 //! This crate provides a Python grammar for the [tree-sitter][] parsing library.
 //!
-//! Typically, you will use the [parser][] function to create a tree-sitter [Parser][] that is
+//! Typically, you will use the [parser func][] function to create a tree-sitter [Parser][] that is
 //! configured to use this grammar, and then use the parser to parse some code:
 //!
 //! ```
@@ -22,7 +22,7 @@
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
-//! [parser]: fn.parser.html
+//! [parser func]: fn.parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
 use tree_sitter::Language;


### PR DESCRIPTION
This adds a Rust package for this language grammar.  This makes it easier to use the Rust tree-sitter bindings with a statically known set of languages, since you can just list them as normal Rust dependencies, instead of having to embed the grammar and set up a build.rs file yourself.