### PR TITLE
Verify successful parse in Rust binding doctest

### DIFF
--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -16,10 +16,10 @@ Typically, you will use the [language][language func] function to add this
 grammar to a tree-sitter [Parser][], and then use the parser to parse some code:
 
 ``` rust
-let code = indoc! {"
+let code = r#"
     def double(x):
         return x * 2
-"};
+"#;
 let mut parser = tree_sitter_python::parser();
 let parsed = parser.parse(code, None);
 ```

--- a/bindings/rust/README.md
+++ b/bindings/rust/README.md
@@ -20,7 +20,8 @@ let code = r#"
     def double(x):
         return x * 2
 "#;
-let mut parser = tree_sitter_python::parser();
+let mut parser = Parser::new();
+parser.set_language(tree_sitter_python::language()).expect("Error loading Python grammar");
 let parsed = parser.parse(code, None);
 ```
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -19,7 +19,9 @@
 //! let mut parser = Parser::new();
 //! parser.set_language(tree_sitter_python::language()).expect("Error loading Python grammar");
 //! let parsed = parser.parse(code, None);
-//! # assert!(parsed.is_some());
+//! # let parsed = parsed.unwrap();
+//! # let root = parsed.root_node();
+//! # assert!(!root.has_error());
 //! ```
 //!
 //! [Language]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Language.html


### PR DESCRIPTION
We were verifying that the parse operation succeeds, but not verifying that the example code was valid.  Now we do!