### PR TITLE
Include query files in Rust bindings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ build = "bindings/rust/build.rs"
 include = [
   "bindings/rust/*",
   "grammar.js",
+  "queries/*",
   "src/*",
 ]
 

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -46,7 +46,7 @@ pub fn language() -> Language {
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
 /// The syntax highlighting query for this language.
-pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../query/highlights.scm");
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../queries/highlights.scm");
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
@@ -54,7 +54,7 @@ pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../query/highlights.s
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
 /// The symbol tagging query for this language.
-pub const TAGGING_QUERY: &'static str = include_str!("../../query/tags.scm");
+pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -43,10 +43,16 @@ pub fn language() -> Language {
 /// The source of the Python tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
+/// The syntax highlighting queries for this language.
+pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
+
+/// The symbol tagging queries for this language.
+pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -45,16 +45,16 @@ pub fn language() -> Language {
 /// The source of the Python tree-sitter grammar description.
 pub const GRAMMAR: &'static str = include_str!("../../grammar.js");
 
-/// The syntax highlighting queries for this language.
-pub const HIGHLIGHT_QUERIES: &'static str = include_str!("../../queries/highlights.scm");
+/// The syntax highlighting query for this language.
+pub const HIGHLIGHT_QUERY: &'static str = include_str!("../../query/highlights.scm");
 
 /// The content of the [`node-types.json`][] file for this grammar.
 ///
 /// [`node-types.json`]: https://tree-sitter.github.io/tree-sitter/using-parsers#static-node-types
 pub const NODE_TYPES: &'static str = include_str!("../../src/node-types.json");
 
-/// The symbol tagging queries for this language.
-pub const TAGGING_QUERIES: &'static str = include_str!("../../queries/tags.scm");
+/// The symbol tagging query for this language.
+pub const TAGGING_QUERY: &'static str = include_str!("../../query/tags.scm");
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
We're already exposing the grammar definition and metadata as static strings.  Compared to that, the query files are tiny enough to include too.