### PR TITLE
mingw gcc on Windows does not include UINT8_MAX in stdint.h

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -4,6 +4,11 @@
 #include <cstring>
 #include <cassert>
 #include <stdio.h>
+
+#ifndef UINT8_MAX
+#define UINT8_MAX 255
+#endif
+
 namespace {
 
 using std::vector;


### PR DESCRIPTION
On windows some people were facing issues when building with mingw as stdint.h did not contain the pound define for UINT8_MAX

Link to github issue going into more detail about this: https://github.com/nvim-treesitter/nvim-treesitter/issues/1876