### PR TITLE
mingw gcc on Windows does not include UINT8_MAX in stdint.h

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -1,3 +1,4 @@
+#define __STDC_LIMIT_MACROS
 #include <tree_sitter/parser.h>
 #include <vector>
 #include <cwctype>


### PR DESCRIPTION
This is from a previous pr I made about the same issue, I found out a better solution to the problem (link to github issue: https://github.com/nvim-treesitter/nvim-treesitter/issues/1876), (link to discussion in previous pr: https://github.com/tree-sitter/tree-sitter-python/pull/130)