### PR TITLE
Fix: include comments at the end of blocks

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -243,7 +243,11 @@ struct Scanner {
         skip(lexer);
       } else if (lexer->lookahead == '#') {
         if (first_comment_indent_length == -1) {
-          first_comment_indent_length = (int32_t)indent_length;
+          // If we haven't found an EOL yet,
+          // then this is a comment after an expression:
+          //   foo = bar # comment
+          // So it's still under the same indentation level.
+          first_comment_indent_length = found_end_of_line? (int32_t)indent_length : indent_length_stack.back();
         }
         while (lexer->lookahead && lexer->lookahead != '\n') {
           skip(lexer);

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -873,19 +873,43 @@ if c:
     # three
       # four
 
+def a():
+    if a:
+        b # comment
+    b # comment
+
 # five
 
 ---
 
 (module
-  (if_statement (identifier) (block
-    (expression_statement (identifier))
-    (comment)
-    (comment)))
-  (if_statement (identifier) (block
-    (expression_statement (identifier))
-    (comment)
-    (comment)))
+  (if_statement
+    (identifier)
+    (block
+      (expression_statement
+        (identifier))
+      (comment)
+      (comment)))
+  (if_statement
+    (identifier)
+    (block
+      (expression_statement
+        (identifier))
+      (comment)
+      (comment)))
+  (function_definition
+    (identifier)
+    (parameters)
+    (block
+      (if_statement
+        (identifier)
+        (block
+          (expression_statement
+            (identifier))
+          (comment)))
+      (expression_statement
+        (identifier))
+      (comment)))
   (comment))
 
 ====================================================


### PR DESCRIPTION
Dedenting was happening too early for inline comments that were after an
expression.

The indentation level for these comments was the number of space between the
expression and the `#` instead of indentation of the expression.

Fixes https://github.com/tree-sitter/tree-sitter-python/issues/113