### PR TITLE
Fix parsing of string literals immediately after syntax errors

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -149,7 +149,9 @@ struct Scanner {
   }
 
   bool scan(TSLexer *lexer, const bool *valid_symbols) {
-    if (valid_symbols[STRING_CONTENT] && !valid_symbols[INDENT] && !delimiter_stack.empty()) {
+    bool error_recovery_mode = valid_symbols[STRING_CONTENT] && valid_symbols[INDENT];
+
+    if (valid_symbols[STRING_CONTENT] && !delimiter_stack.empty() && !error_recovery_mode) {
       Delimiter delimiter = delimiter_stack.back();
       int32_t end_character = delimiter.end_character();
       bool has_content = false;
@@ -272,7 +274,7 @@ struct Scanner {
       }
     }
 
-    if (found_end_of_line) {
+    if (found_end_of_line && !error_recovery_mode) {
       if (!indent_length_stack.empty()) {
         uint16_t current_indent_length = indent_length_stack.back();
 

--- a/test/corpus/errors.txt
+++ b/test/corpus/errors.txt
@@ -1,0 +1,27 @@
+====================================
+An error before a string literal
+====================================
+
+def a(b):
+    c.
+
+    """
+    d
+    """
+
+    e
+
+---
+
+(module
+  (function_definition
+    (identifier)
+    (parameters
+      (identifier))
+    (ERROR
+      (identifier))
+    (block
+      (expression_statement
+        (string))
+      (expression_statement
+        (identifier)))))


### PR DESCRIPTION
Previously, the external scanner would sometimes attempt to return `newline`/`indent`/`dedent` tokens in error recovery mode. But because those tokens are *empty* (they consume zero characters), Tree-sitter currently disallows them in error recovery mode, in order to prevent infinite loops. When no non-zero-length token is found, Tree-sitter skips ahead by one character in order go guarantee forward progress.

The result of this behavior was that the external scanner would fail to recognize a triple-quoted string delimiter if it occurred right after a syntax error. This was reproducible in a text editor by typing `foo.` before a triple-quoted string.

I've fixed it by preventing the external scanner from trying to emit zero-length tokens in error recovery mode.