### PR TITLE
Fix handling of backslashes in raw strings

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -170,7 +170,7 @@ struct Scanner {
             // Step over the backslash.
             lexer->advance(lexer, false);
             // Step over any escaped quotes.
-            if (lexer->lookahead == delimiter.end_character()) {
+            if (lexer->lookahead == delimiter.end_character() || lexer->lookahead == '\\') {
               lexer->advance(lexer, false);
             }
             continue;

--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -167,7 +167,13 @@ struct Scanner {
           return has_content;
         } else if (lexer->lookahead == '\\') {
           if (delimiter.is_raw()) {
+            // Step over the backslash.
             lexer->advance(lexer, false);
+            // Step over any escaped quotes.
+            if (lexer->lookahead == delimiter.end_character()) {
+              lexer->advance(lexer, false);
+            }
+            continue;
           } else if (delimiter.is_bytes()) {
               lexer->mark_end(lexer);
               lexer->advance(lexer, false);

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -190,6 +190,9 @@ Raw strings
 r'ab\x00cd'
 ur"\n"
 
+# raw f-string
+fr"\{0}"
+
 --------------------------------------------------------------------------------
 
 (module
@@ -203,7 +206,12 @@ ur"\n"
   (expression_statement
     (string))
   (expression_statement
-    (string)))
+    (string))
+  (comment)
+  (expression_statement
+    (string
+      (interpolation
+        (integer)))))
 
 ================================================================================
 Raw strings with escaped quotes

--- a/test/corpus/literals.txt
+++ b/test/corpus/literals.txt
@@ -193,6 +193,8 @@ ur"\n"
 # raw f-string
 fr"\{0}"
 
+r"\\"
+
 --------------------------------------------------------------------------------
 
 (module
@@ -211,7 +213,9 @@ fr"\{0}"
   (expression_statement
     (string
       (interpolation
-        (integer)))))
+        (integer))))
+  (expression_statement
+    (string)))
 
 ================================================================================
 Raw strings with escaped quotes


### PR DESCRIPTION
A story in two acts.

Act 1: The scanner consumes too much

Inside raw strings, backslashes are passed through without interpretation. This is implemented in the scanner on lines 168-170:

https://github.com/tree-sitter/tree-sitter-python/blob/b14614e2144b8f9ee54deed5a24f3c6f51f9ffa8/src/scanner.cc#L167-L171

Basically, we call `lexer->advance()` to consume the backslash, and then continue with the scanning.

However, from this point the execution continues until line 227, where we _also_ advance the lexer. The effect of this is that when you write `r"\foo"`, the `f` is never seen by the scanner. For the most part this is unproblematic, but in cases like `fr"\{0}"` we get an error, since the `{` is consumed, and thus the interpolation is never started. Similarly, `fr"\N{latin capital letter a}"` would consume the `N`, and thus not interpret it as a named unicode escape, leading to the substring enclosed in curly braces being interpreted as an interpolation instead.

The fix is straightforward: we simply `continue` after advancing the lexer over the backslash.

Or... It would be straightforward, but there's a catch.

Act 2: The scanner (now) doesn't consume enough

When I said above that backslashes in raw strings are passed through without interpretation, that was not entirely true. Backslashes in raw strings _do_ escape quotes. This means that the above fix breaks when parsing strings such as `r"\""`, because we now consume the backslash and then terminate the string too early at the quote character immediately after.

To fix this, after advancing the lexer we check if the lookahead is the same character as the ending character of the string. If so, we we also consume that character.

---
See https://github.com/tree-sitter/tree-sitter-python/pull/182/commits/285f84e5c810916f7718c5163b8585219ca718c8 for the current behaviour of the scanner/parser.