### PR TITLE
Add module tag query

### DIFF
--- a/queries/tags.scm
+++ b/queries/tags.scm
@@ -1,3 +1,5 @@
+(module (expression_statement (assignment left: (identifier) @name) @definition.constant))
+
 (class_definition
   name: (identifier) @name) @definition.class
 


### PR DESCRIPTION
This patch adds an additional tag query to capture top-level constant assignments.  This does not impact the grammar or change the parser and upstreams a tag query used to generate symbol data within GitHub from `tree-sitter-python` parse trees.