### PR TITLE
Improve field names for 'string' rule

### DIFF
--- a/grammar.js
+++ b/grammar.js
@@ -930,12 +930,12 @@ module.exports = grammar({
     ),
 
     string: $ => seq(
-      field('prefix', alias($._string_start, '"')),
+      field('open', alias($._string_start, '"')),
       repeat(choice(
-        field('interpolation', $.interpolation),
-        field('string_content', $.string_content)
+        field('nested', $.interpolation),
+        field('value', $.string_content),
       )),
-      field('suffix', alias($._string_end, '"'))
+      field('close', alias($._string_end, '"'))
     ),
 
     string_content: $ => prec.right(0, repeat1(

--- a/src/grammar.json
+++ b/src/grammar.json
@@ -4596,7 +4596,7 @@
       "members": [
         {
           "type": "FIELD",
-          "name": "prefix",
+          "name": "open",
           "content": {
             "type": "ALIAS",
             "content": {
@@ -4614,7 +4614,7 @@
             "members": [
               {
                 "type": "FIELD",
-                "name": "interpolation",
+                "name": "nested",
                 "content": {
                   "type": "SYMBOL",
                   "name": "interpolation"
@@ -4622,7 +4622,7 @@
               },
               {
                 "type": "FIELD",
-                "name": "string_content",
+                "name": "value",
                 "content": {
                   "type": "SYMBOL",
                   "name": "string_content"
@@ -4633,7 +4633,7 @@
         },
         {
           "type": "FIELD",
-          "name": "suffix",
+          "name": "close",
           "content": {
             "type": "ALIAS",
             "content": {

--- a/src/node-types.json
+++ b/src/node-types.json
@@ -2354,7 +2354,17 @@
     "type": "string",
     "named": true,
     "fields": {
-      "interpolation": {
+      "close": {
+        "multiple": false,
+        "required": true,
+        "types": [
+          {
+            "type": "\"",
+            "named": false
+          }
+        ]
+      },
+      "nested": {
         "multiple": true,
         "required": false,
         "types": [
@@ -2364,7 +2374,7 @@
           }
         ]
       },
-      "prefix": {
+      "open": {
         "multiple": false,
         "required": true,
         "types": [
@@ -2374,23 +2384,13 @@
           }
         ]
       },
-      "string_content": {
+      "value": {
         "multiple": true,
         "required": false,
         "types": [
           {
             "type": "string_content",
             "named": true
-          }
-        ]
-      },
-      "suffix": {
-        "multiple": false,
-        "required": true,
-        "types": [
-          {
-            "type": "\"",
-            "named": false
           }
         ]
       }

--- a/src/parser.c
+++ b/src/parser.c
@@ -12,9 +12,9 @@
 #define ALIAS_COUNT 5
 #define TOKEN_COUNT 106
 #define EXTERNAL_TOKEN_COUNT 10
-#define FIELD_COUNT 36
+#define FIELD_COUNT 35
 #define MAX_ALIAS_SEQUENCE_LENGTH 9
-#define PRODUCTION_ID_COUNT 134
+#define PRODUCTION_ID_COUNT 133
 
 enum {
   sym_identifier = 1,
@@ -1789,35 +1789,34 @@ enum {
   field_attribute = 5,
   field_body = 6,
   field_cause = 7,
-  field_code = 8,
-  field_condition = 9,
-  field_consequence = 10,
-  field_definition = 11,
-  field_expression = 12,
-  field_format_specifier = 13,
-  field_function = 14,
-  field_guard = 15,
-  field_interpolation = 16,
+  field_close = 8,
+  field_code = 9,
+  field_condition = 10,
+  field_consequence = 11,
+  field_definition = 12,
+  field_expression = 13,
+  field_format_specifier = 14,
+  field_function = 15,
+  field_guard = 16,
   field_key = 17,
   field_left = 18,
   field_module_name = 19,
   field_name = 20,
-  field_object = 21,
-  field_operator = 22,
-  field_operators = 23,
-  field_parameters = 24,
-  field_pattern = 25,
-  field_prefix = 26,
-  field_return_type = 27,
-  field_right = 28,
-  field_string_content = 29,
+  field_nested = 21,
+  field_object = 22,
+  field_open = 23,
+  field_operator = 24,
+  field_operators = 25,
+  field_parameters = 26,
+  field_pattern = 27,
+  field_return_type = 28,
+  field_right = 29,
   field_subject = 30,
   field_subscript = 31,
-  field_suffix = 32,
-  field_superclasses = 33,
-  field_type = 34,
-  field_type_conversion = 35,
-  field_value = 36,
+  field_superclasses = 32,
+  field_type = 33,
+  field_type_conversion = 34,
+  field_value = 35,
 };
 
 static const char * const ts_field_names[] = {
@@ -1829,6 +1828,7 @@ static const char * const ts_field_names[] = {
   [field_attribute] = "attribute",
   [field_body] = "body",
   [field_cause] = "cause",
+  [field_close] = "close",
   [field_code] = "code",
   [field_condition] = "condition",
   [field_consequence] = "consequence",
@@ -1837,23 +1837,21 @@ static const char * const ts_field_names[] = {
   [field_format_specifier] = "format_specifier",
   [field_function] = "function",
   [field_guard] = "guard",
-  [field_interpolation] = "interpolation",
   [field_key] = "key",
   [field_left] = "left",
   [field_module_name] = "module_name",
   [field_name] = "name",
+  [field_nested] = "nested",
   [field_object] = "object",
+  [field_open] = "open",
   [field_operator] = "operator",
   [field_operators] = "operators",
   [field_parameters] = "parameters",
   [field_pattern] = "pattern",
-  [field_prefix] = "prefix",
   [field_return_type] = "return_type",
   [field_right] = "right",
-  [field_string_content] = "string_content",
   [field_subject] = "subject",
   [field_subscript] = "subscript",
-  [field_suffix] = "suffix",
   [field_superclasses] = "superclasses",
   [field_type] = "type",
   [field_type_conversion] = "type_conversion",
@@ -1868,135 +1866,134 @@ static const TSFieldMapSlice ts_field_map_slices[PRODUCTION_ID_COUNT] = {
   [6] = {.index = 5, .length = 1},
   [8] = {.index = 6, .length = 1},
   [9] = {.index = 7, .length = 1},
-  [10] = {.index = 8, .length = 1},
-  [11] = {.index = 9, .length = 2},
-  [12] = {.index = 11, .length = 2},
+  [10] = {.index = 8, .length = 2},
+  [11] = {.index = 10, .length = 2},
+  [12] = {.index = 12, .length = 1},
   [13] = {.index = 13, .length = 1},
-  [14] = {.index = 14, .length = 1},
-  [15] = {.index = 15, .length = 4},
-  [16] = {.index = 19, .length = 4},
-  [17] = {.index = 23, .length = 2},
-  [18] = {.index = 25, .length = 1},
-  [19] = {.index = 26, .length = 2},
+  [14] = {.index = 14, .length = 4},
+  [15] = {.index = 18, .length = 4},
+  [16] = {.index = 22, .length = 2},
+  [17] = {.index = 24, .length = 1},
+  [18] = {.index = 25, .length = 2},
+  [19] = {.index = 27, .length = 1},
   [20] = {.index = 28, .length = 1},
   [21] = {.index = 29, .length = 1},
-  [22] = {.index = 30, .length = 1},
-  [23] = {.index = 31, .length = 2},
-  [24] = {.index = 33, .length = 2},
-  [25] = {.index = 35, .length = 2},
-  [26] = {.index = 37, .length = 3},
-  [27] = {.index = 40, .length = 1},
-  [28] = {.index = 41, .length = 2},
-  [29] = {.index = 43, .length = 1},
-  [30] = {.index = 44, .length = 2},
+  [22] = {.index = 30, .length = 2},
+  [23] = {.index = 32, .length = 2},
+  [24] = {.index = 34, .length = 2},
+  [25] = {.index = 36, .length = 3},
+  [26] = {.index = 39, .length = 1},
+  [27] = {.index = 40, .length = 2},
+  [28] = {.index = 42, .length = 1},
+  [29] = {.index = 43, .length = 2},
+  [30] = {.index = 45, .length = 1},
   [31] = {.index = 46, .length = 1},
-  [32] = {.index = 47, .length = 1},
-  [33] = {.index = 48, .length = 2},
-  [34] = {.index = 50, .length = 2},
-  [35] = {.index = 52, .length = 1},
-  [36] = {.index = 53, .length = 2},
-  [37] = {.index = 55, .length = 1},
-  [39] = {.index = 56, .length = 1},
-  [40] = {.index = 57, .length = 2},
-  [41] = {.index = 59, .length = 1},
-  [42] = {.index = 60, .length = 2},
-  [43] = {.index = 62, .length = 1},
-  [44] = {.index = 63, .length = 2},
-  [45] = {.index = 65, .length = 2},
-  [46] = {.index = 67, .length = 2},
-  [47] = {.index = 69, .length = 2},
-  [48] = {.index = 30, .length = 1},
-  [49] = {.index = 71, .length = 1},
-  [50] = {.index = 72, .length = 2},
-  [51] = {.index = 74, .length = 1},
-  [52] = {.index = 75, .length = 2},
-  [53] = {.index = 77, .length = 2},
-  [54] = {.index = 79, .length = 2},
-  [55] = {.index = 81, .length = 2},
-  [56] = {.index = 81, .length = 2},
-  [58] = {.index = 83, .length = 2},
-  [59] = {.index = 85, .length = 2},
-  [60] = {.index = 87, .length = 3},
-  [61] = {.index = 90, .length = 3},
-  [62] = {.index = 93, .length = 3},
-  [63] = {.index = 96, .length = 2},
-  [64] = {.index = 98, .length = 2},
-  [65] = {.index = 100, .length = 3},
-  [66] = {.index = 103, .length = 1},
-  [67] = {.index = 104, .length = 3},
-  [68] = {.index = 107, .length = 3},
-  [69] = {.index = 110, .length = 2},
-  [70] = {.index = 112, .length = 2},
-  [71] = {.index = 114, .length = 3},
-  [72] = {.index = 117, .length = 3},
-  [73] = {.index = 120, .length = 3},
-  [74] = {.index = 123, .length = 3},
-  [75] = {.index = 31, .length = 2},
-  [76] = {.index = 126, .length = 1},
-  [77] = {.index = 127, .length = 3},
-  [78] = {.index = 130, .length = 2},
-  [79] = {.index = 132, .length = 2},
-  [80] = {.index = 134, .length = 2},
-  [81] = {.index = 136, .length = 3},
-  [82] = {.index = 139, .length = 1},
-  [83] = {.index = 140, .length = 2},
-  [84] = {.index = 142, .length = 2},
-  [85] = {.index = 144, .length = 4},
-  [86] = {.index = 148, .length = 4},
-  [87] = {.index = 152, .length = 4},
-  [88] = {.index = 156, .length = 3},
-  [89] = {.index = 159, .length = 2},
-  [90] = {.index = 161, .length = 3},
-  [91] = {.index = 164, .length = 3},
-  [92] = {.index = 167, .length = 4},
-  [94] = {.index = 171, .length = 4},
-  [95] = {.index = 175, .length = 4},
-  [96] = {.index = 179, .length = 3},
-  [97] = {.index = 182, .length = 3},
-  [98] = {.index = 185, .length = 2},
-  [99] = {.index = 187, .length = 3},
-  [100] = {.index = 190, .length = 5},
-  [101] = {.index = 195, .length = 1},
-  [102] = {.index = 196, .length = 2},
-  [103] = {.index = 198, .length = 2},
-  [104] = {.index = 200, .length = 3},
-  [105] = {.index = 203, .length = 4},
-  [106] = {.index = 207, .length = 4},
-  [107] = {.index = 211, .length = 4},
-  [109] = {.index = 215, .length = 4},
-  [110] = {.index = 219, .length = 3},
-  [111] = {.index = 222, .length = 2},
-  [112] = {.index = 224, .length = 3},
-  [113] = {.index = 227, .length = 3},
-  [114] = {.index = 230, .length = 3},
-  [115] = {.index = 233, .length = 4},
-  [116] = {.index = 237, .length = 4},
-  [117] = {.index = 241, .length = 4},
-  [118] = {.index = 245, .length = 5},
-  [119] = {.index = 250, .length = 5},
-  [120] = {.index = 255, .length = 3},
-  [121] = {.index = 258, .length = 3},
-  [122] = {.index = 261, .length = 4},
-  [123] = {.index = 265, .length = 3},
-  [124] = {.index = 268, .length = 4},
-  [125] = {.index = 272, .length = 4},
-  [126] = {.index = 276, .length = 5},
-  [127] = {.index = 281, .length = 5},
-  [129] = {.index = 286, .length = 4},
-  [130] = {.index = 290, .length = 4},
-  [131] = {.index = 294, .length = 4},
-  [132] = {.index = 298, .length = 5},
-  [133] = {.index = 303, .length = 5},
+  [32] = {.index = 47, .length = 2},
+  [33] = {.index = 49, .length = 2},
+  [34] = {.index = 51, .length = 1},
+  [35] = {.index = 52, .length = 2},
+  [36] = {.index = 54, .length = 1},
+  [38] = {.index = 55, .length = 1},
+  [39] = {.index = 56, .length = 2},
+  [40] = {.index = 58, .length = 1},
+  [41] = {.index = 59, .length = 2},
+  [42] = {.index = 61, .length = 1},
+  [43] = {.index = 62, .length = 2},
+  [44] = {.index = 64, .length = 2},
+  [45] = {.index = 66, .length = 2},
+  [46] = {.index = 68, .length = 2},
+  [47] = {.index = 29, .length = 1},
+  [48] = {.index = 70, .length = 1},
+  [49] = {.index = 71, .length = 2},
+  [50] = {.index = 73, .length = 1},
+  [51] = {.index = 74, .length = 2},
+  [52] = {.index = 76, .length = 2},
+  [53] = {.index = 78, .length = 2},
+  [54] = {.index = 80, .length = 2},
+  [55] = {.index = 80, .length = 2},
+  [57] = {.index = 82, .length = 2},
+  [58] = {.index = 84, .length = 2},
+  [59] = {.index = 86, .length = 3},
+  [60] = {.index = 89, .length = 3},
+  [61] = {.index = 92, .length = 3},
+  [62] = {.index = 95, .length = 2},
+  [63] = {.index = 97, .length = 2},
+  [64] = {.index = 99, .length = 3},
+  [65] = {.index = 102, .length = 1},
+  [66] = {.index = 103, .length = 3},
+  [67] = {.index = 106, .length = 3},
+  [68] = {.index = 109, .length = 2},
+  [69] = {.index = 111, .length = 2},
+  [70] = {.index = 113, .length = 3},
+  [71] = {.index = 116, .length = 3},
+  [72] = {.index = 119, .length = 3},
+  [73] = {.index = 122, .length = 3},
+  [74] = {.index = 30, .length = 2},
+  [75] = {.index = 125, .length = 1},
+  [76] = {.index = 126, .length = 3},
+  [77] = {.index = 129, .length = 2},
+  [78] = {.index = 131, .length = 2},
+  [79] = {.index = 133, .length = 2},
+  [80] = {.index = 135, .length = 3},
+  [81] = {.index = 138, .length = 1},
+  [82] = {.index = 139, .length = 2},
+  [83] = {.index = 141, .length = 2},
+  [84] = {.index = 143, .length = 4},
+  [85] = {.index = 147, .length = 4},
+  [86] = {.index = 151, .length = 4},
+  [87] = {.index = 155, .length = 3},
+  [88] = {.index = 158, .length = 2},
+  [89] = {.index = 160, .length = 3},
+  [90] = {.index = 163, .length = 3},
+  [91] = {.index = 166, .length = 4},
+  [93] = {.index = 170, .length = 4},
+  [94] = {.index = 174, .length = 4},
+  [95] = {.index = 178, .length = 3},
+  [96] = {.index = 181, .length = 3},
+  [97] = {.index = 184, .length = 2},
+  [98] = {.index = 186, .length = 3},
+  [99] = {.index = 189, .length = 5},
+  [100] = {.index = 194, .length = 1},
+  [101] = {.index = 195, .length = 2},
+  [102] = {.index = 197, .length = 2},
+  [103] = {.index = 199, .length = 3},
+  [104] = {.index = 202, .length = 4},
+  [105] = {.index = 206, .length = 4},
+  [106] = {.index = 210, .length = 4},
+  [108] = {.index = 214, .length = 4},
+  [109] = {.index = 218, .length = 3},
+  [110] = {.index = 221, .length = 2},
+  [111] = {.index = 223, .length = 3},
+  [112] = {.index = 226, .length = 3},
+  [113] = {.index = 229, .length = 3},
+  [114] = {.index = 232, .length = 4},
+  [115] = {.index = 236, .length = 4},
+  [116] = {.index = 240, .length = 4},
+  [117] = {.index = 244, .length = 5},
+  [118] = {.index = 249, .length = 5},
+  [119] = {.index = 254, .length = 3},
+  [120] = {.index = 257, .length = 3},
+  [121] = {.index = 260, .length = 4},
+  [122] = {.index = 264, .length = 3},
+  [123] = {.index = 267, .length = 4},
+  [124] = {.index = 271, .length = 4},
+  [125] = {.index = 275, .length = 5},
+  [126] = {.index = 280, .length = 5},
+  [128] = {.index = 285, .length = 4},
+  [129] = {.index = 289, .length = 4},
+  [130] = {.index = 293, .length = 4},
+  [131] = {.index = 297, .length = 5},
+  [132] = {.index = 302, .length = 5},
 };
 
 static const TSFieldMapEntry ts_field_map_entries[] = {
   [0] =
-    {field_prefix, 0},
-    {field_suffix, 1},
+    {field_close, 1},
+    {field_open, 0},
   [2] =
-    {field_string_content, 0},
+    {field_value, 0},
   [3] =
-    {field_interpolation, 0},
+    {field_nested, 0},
   [4] =
     {field_name, 1, .inherited = true},
   [5] =
@@ -2004,418 +2001,416 @@ static const TSFieldMapEntry ts_field_map_entries[] = {
   [6] =
     {field_argument, 1},
   [7] =
-    {field_value, 0},
-  [8] =
     {field_code, 1},
-  [9] =
+  [8] =
     {field_argument, 1},
     {field_operator, 0},
-  [11] =
+  [10] =
     {field_arguments, 1},
     {field_function, 0},
-  [13] =
+  [12] =
     {field_operators, 1, .inherited = true},
-  [14] =
+  [13] =
     {field_definition, 1},
-  [15] =
-    {field_interpolation, 1, .inherited = true},
-    {field_prefix, 0},
-    {field_string_content, 1, .inherited = true},
-    {field_suffix, 2},
-  [19] =
-    {field_interpolation, 0, .inherited = true},
-    {field_interpolation, 1, .inherited = true},
-    {field_string_content, 0, .inherited = true},
-    {field_string_content, 1, .inherited = true},
-  [23] =
+  [14] =
+    {field_close, 2},
+    {field_nested, 1, .inherited = true},
+    {field_open, 0},
+    {field_value, 1, .inherited = true},
+  [18] =
+    {field_nested, 0, .inherited = true},
+    {field_nested, 1, .inherited = true},
+    {field_value, 0, .inherited = true},
+    {field_value, 1, .inherited = true},
+  [22] =
     {field_name, 0},
     {field_name, 1, .inherited = true},
-  [25] =
+  [24] =
     {field_argument, 2, .inherited = true},
-  [26] =
+  [25] =
     {field_argument, 1},
     {field_argument, 2, .inherited = true},
-  [28] =
+  [27] =
     {field_cause, 2},
-  [29] =
+  [28] =
     {field_subject, 1},
-  [30] =
+  [29] =
     {field_body, 2},
-  [31] =
+  [30] =
     {field_name, 0},
     {field_value, 2},
-  [33] =
+  [32] =
     {field_left, 0},
     {field_type, 2},
-  [35] =
+  [34] =
     {field_left, 0},
     {field_right, 2},
-  [37] =
+  [36] =
     {field_left, 0},
     {field_operator, 1},
     {field_right, 2},
-  [40] =
+  [39] =
     {field_alias, 2},
-  [41] =
+  [40] =
     {field_attribute, 2},
     {field_object, 0},
-  [43] =
+  [42] =
     {field_operators, 0},
-  [44] =
+  [43] =
     {field_operators, 0, .inherited = true},
     {field_operators, 1, .inherited = true},
-  [46] =
+  [45] =
     {field_expression, 1},
-  [47] =
+  [46] =
     {field_name, 1},
-  [48] =
+  [47] =
     {field_name, 0, .inherited = true},
     {field_name, 1, .inherited = true},
-  [50] =
+  [49] =
     {field_alias, 2},
     {field_name, 0},
+  [51] =
+    {field_name, 3, .inherited = true},
   [52] =
-    {field_name, 3, .inherited = true},
-  [53] =
     {field_module_name, 1},
     {field_name, 3, .inherited = true},
+  [54] =
+    {field_module_name, 1},
   [55] =
-    {field_module_name, 1},
-  [56] =
     {field_body, 1},
-  [57] =
+  [56] =
     {field_argument, 0, .inherited = true},
     {field_argument, 1, .inherited = true},
-  [59] =
+  [58] =
     {field_cause, 3},
-  [60] =
+  [59] =
     {field_condition, 1},
     {field_consequence, 3},
-  [62] =
+  [61] =
     {field_alternative, 0},
-  [63] =
+  [62] =
     {field_alternative, 3, .inherited = true},
     {field_subject, 1},
-  [65] =
+  [64] =
     {field_subject, 1},
     {field_subject, 2, .inherited = true},
-  [67] =
+  [66] =
     {field_subject, 0, .inherited = true},
     {field_subject, 1, .inherited = true},
-  [69] =
+  [68] =
     {field_body, 3},
     {field_condition, 1},
+  [70] =
+    {field_body, 3},
   [71] =
     {field_body, 3},
-  [72] =
-    {field_body, 3},
     {field_name, 1},
-  [74] =
+  [73] =
     {field_type, 2},
-  [75] =
+  [74] =
     {field_body, 3},
     {field_parameters, 1},
-  [77] =
+  [76] =
     {field_key, 0},
     {field_value, 2},
-  [79] =
+  [78] =
     {field_subscript, 2},
     {field_value, 0},
-  [81] =
+  [80] =
     {field_operators, 0},
     {field_operators, 1},
-  [83] =
+  [82] =
     {field_expression, 1},
     {field_type_conversion, 2},
-  [85] =
+  [84] =
     {field_expression, 1},
     {field_format_specifier, 2},
-  [87] =
+  [86] =
     {field_alternative, 4},
     {field_condition, 1},
     {field_consequence, 3},
-  [90] =
+  [89] =
     {field_alternative, 4, .inherited = true},
     {field_condition, 1},
     {field_consequence, 3},
-  [93] =
+  [92] =
     {field_condition, 1},
     {field_consequence, 3},
     {field_consequence, 4},
-  [96] =
+  [95] =
     {field_alternative, 4, .inherited = true},
     {field_subject, 1},
-  [98] =
+  [97] =
     {field_alternative, 0, .inherited = true},
     {field_alternative, 1, .inherited = true},
-  [100] =
+  [99] =
     {field_alternative, 4, .inherited = true},
     {field_subject, 1},
     {field_subject, 2, .inherited = true},
-  [103] =
+  [102] =
     {field_body, 4},
-  [104] =
+  [103] =
     {field_alternative, 4},
     {field_body, 3},
     {field_condition, 1},
-  [107] =
+  [106] =
     {field_body, 3},
     {field_body, 4},
     {field_condition, 1},
-  [110] =
+  [109] =
     {field_body, 2},
     {field_body, 3},
-  [112] =
+  [111] =
     {field_body, 3},
     {field_body, 4},
-  [114] =
+  [113] =
     {field_body, 4},
     {field_name, 1},
     {field_parameters, 2},
-  [117] =
+  [116] =
     {field_body, 3},
     {field_body, 4},
     {field_name, 1},
-  [120] =
+  [119] =
     {field_body, 4},
     {field_name, 1},
     {field_superclasses, 2},
-  [123] =
+  [122] =
     {field_left, 0},
     {field_right, 4},
     {field_type, 2},
-  [126] =
+  [125] =
     {field_subscript, 1},
-  [127] =
+  [126] =
     {field_subscript, 2},
     {field_subscript, 3, .inherited = true},
     {field_value, 0},
-  [130] =
+  [129] =
     {field_subscript, 0, .inherited = true},
     {field_subscript, 1, .inherited = true},
-  [132] =
+  [131] =
     {field_expression, 1},
     {field_type_conversion, 3},
-  [134] =
+  [133] =
     {field_expression, 1},
     {field_format_specifier, 3},
-  [136] =
+  [135] =
     {field_expression, 1},
     {field_format_specifier, 3},
     {field_type_conversion, 2},
-  [139] =
+  [138] =
     {field_name, 4, .inherited = true},
-  [140] =
+  [139] =
     {field_module_name, 1},
     {field_name, 4, .inherited = true},
-  [142] =
+  [141] =
     {field_left, 1},
     {field_right, 3},
-  [144] =
+  [143] =
     {field_alternative, 4, .inherited = true},
     {field_alternative, 5},
     {field_condition, 1},
     {field_consequence, 3},
-  [148] =
+  [147] =
     {field_alternative, 5},
     {field_condition, 1},
     {field_consequence, 3},
     {field_consequence, 4},
-  [152] =
+  [151] =
     {field_alternative, 5, .inherited = true},
     {field_condition, 1},
     {field_consequence, 3},
     {field_consequence, 4},
-  [156] =
+  [155] =
     {field_alternative, 5, .inherited = true},
     {field_subject, 1},
     {field_subject, 2, .inherited = true},
-  [159] =
+  [158] =
     {field_body, 4},
     {field_body, 5},
-  [161] =
+  [160] =
     {field_body, 5},
     {field_name, 2},
     {field_parameters, 3},
-  [164] =
+  [163] =
     {field_body, 5},
     {field_left, 1},
     {field_right, 3},
-  [167] =
+  [166] =
     {field_alternative, 5},
     {field_body, 3},
     {field_body, 4},
     {field_condition, 1},
-  [171] =
+  [170] =
     {field_body, 4},
     {field_body, 5},
     {field_name, 1},
     {field_parameters, 2},
-  [175] =
+  [174] =
     {field_body, 4},
     {field_body, 5},
     {field_name, 1},
     {field_superclasses, 2},
-  [179] =
+  [178] =
     {field_name, 0},
     {field_type, 2},
     {field_value, 4},
-  [182] =
+  [181] =
     {field_expression, 1},
     {field_format_specifier, 4},
     {field_type_conversion, 3},
-  [185] =
+  [184] =
     {field_left, 2},
     {field_right, 4},
-  [187] =
+  [186] =
     {field_left, 1},
     {field_right, 3},
     {field_right, 4},
-  [190] =
+  [189] =
     {field_alternative, 5, .inherited = true},
     {field_alternative, 6},
     {field_condition, 1},
     {field_consequence, 3},
     {field_consequence, 4},
-  [195] =
+  [194] =
     {field_pattern, 1},
-  [196] =
+  [195] =
     {field_consequence, 3},
     {field_pattern, 1},
-  [198] =
+  [197] =
     {field_pattern, 0, .inherited = true},
     {field_pattern, 1, .inherited = true},
-  [200] =
+  [199] =
     {field_body, 6},
     {field_left, 2},
     {field_right, 4},
-  [203] =
+  [202] =
     {field_body, 5},
     {field_body, 6},
     {field_name, 2},
     {field_parameters, 3},
-  [207] =
+  [206] =
     {field_alternative, 6},
     {field_body, 5},
     {field_left, 1},
     {field_right, 3},
-  [211] =
+  [210] =
     {field_body, 5},
     {field_body, 6},
     {field_left, 1},
     {field_right, 3},
-  [215] =
+  [214] =
     {field_body, 6},
     {field_name, 1},
     {field_parameters, 2},
     {field_return_type, 4},
-  [219] =
+  [218] =
     {field_left, 2},
     {field_right, 4},
     {field_right, 5},
-  [222] =
+  [221] =
     {field_consequence, 4},
     {field_pattern, 1},
-  [224] =
+  [223] =
     {field_consequence, 3},
     {field_consequence, 4},
     {field_pattern, 1},
-  [227] =
+  [226] =
     {field_consequence, 4},
     {field_guard, 2},
     {field_pattern, 1},
-  [230] =
+  [229] =
     {field_consequence, 4},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [233] =
+  [232] =
     {field_alternative, 7},
     {field_body, 6},
     {field_left, 2},
     {field_right, 4},
-  [237] =
+  [236] =
     {field_body, 6},
     {field_body, 7},
     {field_left, 2},
     {field_right, 4},
-  [241] =
+  [240] =
     {field_body, 7},
     {field_name, 2},
     {field_parameters, 3},
     {field_return_type, 5},
-  [245] =
+  [244] =
     {field_alternative, 7},
     {field_body, 5},
     {field_body, 6},
     {field_left, 1},
     {field_right, 3},
-  [250] =
+  [249] =
     {field_body, 6},
     {field_body, 7},
     {field_name, 1},
     {field_parameters, 2},
     {field_return_type, 4},
-  [255] =
+  [254] =
     {field_consequence, 4},
     {field_consequence, 5},
     {field_pattern, 1},
-  [258] =
+  [257] =
     {field_consequence, 5},
     {field_guard, 3},
     {field_pattern, 1},
-  [261] =
+  [260] =
     {field_consequence, 4},
     {field_consequence, 5},
     {field_guard, 2},
     {field_pattern, 1},
-  [265] =
+  [264] =
     {field_consequence, 5},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [268] =
+  [267] =
     {field_consequence, 4},
     {field_consequence, 5},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [272] =
+  [271] =
     {field_consequence, 5},
     {field_guard, 3},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [276] =
+  [275] =
     {field_alternative, 8},
     {field_body, 6},
     {field_body, 7},
     {field_left, 2},
     {field_right, 4},
-  [281] =
+  [280] =
     {field_body, 7},
     {field_body, 8},
     {field_name, 2},
     {field_parameters, 3},
     {field_return_type, 5},
-  [286] =
+  [285] =
     {field_consequence, 5},
     {field_consequence, 6},
     {field_guard, 3},
     {field_pattern, 1},
-  [290] =
+  [289] =
     {field_consequence, 5},
     {field_consequence, 6},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [294] =
+  [293] =
     {field_consequence, 6},
     {field_guard, 4},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [298] =
+  [297] =
     {field_consequence, 5},
     {field_consequence, 6},
     {field_guard, 3},
     {field_pattern, 1},
     {field_pattern, 2, .inherited = true},
-  [303] =
+  [302] =
     {field_consequence, 6},
     {field_consequence, 7},
     {field_guard, 4},
@@ -2431,149 +2426,149 @@ static const TSSymbol ts_alias_sequences[PRODUCTION_ID_COUNT][MAX_ALIAS_SEQUENCE
   [7] = {
     [1] = sym_identifier,
   },
-  [27] = {
+  [26] = {
     [2] = alias_sym_as_pattern_target,
   },
-  [38] = {
+  [37] = {
     [1] = sym_parenthesized_expression,
   },
-  [42] = {
+  [41] = {
+    [3] = sym_block,
+  },
+  [46] = {
     [3] = sym_block,
   },
   [47] = {
-    [3] = sym_block,
+    [2] = sym_block,
   },
   [48] = {
-    [2] = sym_block,
+    [3] = sym_block,
   },
   [49] = {
     [3] = sym_block,
   },
-  [50] = {
-    [3] = sym_block,
-  },
-  [55] = {
+  [54] = {
     [0] = anon_alias_sym_notin,
     [1] = anon_alias_sym_notin,
   },
-  [56] = {
+  [55] = {
     [0] = anon_alias_sym_isnot,
     [1] = anon_alias_sym_isnot,
   },
-  [57] = {
+  [56] = {
     [0] = alias_sym_format_expression,
+  },
+  [59] = {
+    [3] = sym_block,
   },
   [60] = {
     [3] = sym_block,
   },
-  [61] = {
-    [3] = sym_block,
+  [65] = {
+    [4] = sym_block,
   },
   [66] = {
-    [4] = sym_block,
-  },
-  [67] = {
     [3] = sym_block,
   },
-  [71] = {
+  [70] = {
     [4] = sym_block,
   },
-  [73] = {
+  [72] = {
     [4] = sym_block,
   },
-  [75] = {
+  [74] = {
     [0] = sym_identifier,
   },
-  [85] = {
+  [84] = {
     [3] = sym_block,
+  },
+  [89] = {
+    [5] = sym_block,
   },
   [90] = {
     [5] = sym_block,
   },
-  [91] = {
-    [5] = sym_block,
-  },
-  [93] = {
+  [92] = {
     [2] = sym_block,
+  },
+  [100] = {
+    [1] = alias_sym_case_pattern,
   },
   [101] = {
     [1] = alias_sym_case_pattern,
-  },
-  [102] = {
-    [1] = alias_sym_case_pattern,
     [3] = sym_block,
   },
-  [104] = {
+  [103] = {
     [6] = sym_block,
   },
-  [106] = {
+  [105] = {
     [5] = sym_block,
   },
-  [108] = {
+  [107] = {
     [3] = sym_block,
   },
-  [109] = {
+  [108] = {
     [6] = sym_block,
   },
-  [111] = {
+  [110] = {
     [1] = alias_sym_case_pattern,
     [4] = sym_block,
   },
+  [111] = {
+    [1] = alias_sym_case_pattern,
+  },
   [112] = {
     [1] = alias_sym_case_pattern,
+    [4] = sym_block,
   },
   [113] = {
     [1] = alias_sym_case_pattern,
     [4] = sym_block,
   },
   [114] = {
-    [1] = alias_sym_case_pattern,
-    [4] = sym_block,
-  },
-  [115] = {
     [6] = sym_block,
   },
-  [117] = {
+  [116] = {
     [7] = sym_block,
+  },
+  [119] = {
+    [1] = alias_sym_case_pattern,
   },
   [120] = {
     [1] = alias_sym_case_pattern,
+    [5] = sym_block,
   },
   [121] = {
     [1] = alias_sym_case_pattern,
-    [5] = sym_block,
   },
   [122] = {
     [1] = alias_sym_case_pattern,
+    [5] = sym_block,
   },
   [123] = {
     [1] = alias_sym_case_pattern,
-    [5] = sym_block,
   },
   [124] = {
     [1] = alias_sym_case_pattern,
+    [5] = sym_block,
   },
-  [125] = {
-    [1] = alias_sym_case_pattern,
+  [127] = {
     [5] = sym_block,
   },
   [128] = {
-    [5] = sym_block,
+    [1] = alias_sym_case_pattern,
   },
   [129] = {
     [1] = alias_sym_case_pattern,
   },
   [130] = {
     [1] = alias_sym_case_pattern,
+    [6] = sym_block,
   },
   [131] = {
     [1] = alias_sym_case_pattern,
-    [6] = sym_block,
   },
   [132] = {
-    [1] = alias_sym_case_pattern,
-  },
-  [133] = {
     [1] = alias_sym_case_pattern,
   },
 };
@@ -4828,10 +4823,10 @@ static const TSStateId ts_primary_state_ids[STATE_COUNT] = {
 };
 
 static inline bool sym_identifier_character_set_1(int32_t c) {
-  return (c < 43514
-    ? (c < 4193
-      ? (c < 2707
-        ? (c < 1994
+  return (c < 43646
+    ? (c < 4213
+      ? (c < 2738
+        ? (c < 2036
           ? (c < 931
             ? (c < 748
               ? (c < 192
@@ -4858,781 +4853,803 @@ static inline bool sym_identifier_character_set_1(int32_t c) {
                     ? c == 902
                     : c <= 906)
                   : (c <= 908 || (c >= 910 && c <= 929)))))))
-            : (c <= 1013 || (c < 1649
-              ? (c < 1376
+            : (c <= 1013 || (c < 1749
+              ? (c < 1488
                 ? (c < 1329
                   ? (c < 1162
                     ? (c >= 1015 && c <= 1153)
                     : c <= 1327)
-                  : (c <= 1366 || c == 1369))
-                : (c <= 1416 || (c < 1568
-                  ? (c < 1519
-                    ? (c >= 1488 && c <= 1514)
-                    : c <= 1522)
-                  : (c <= 1610 || (c >= 1646 && c <= 1647)))))
-              : (c <= 1747 || (c < 1791
-                ? (c < 1774
-                  ? (c < 1765
-                    ? c == 1749
-                    : c <= 1766)
-                  : (c <= 1775 || (c >= 1786 && c <= 1788)))
-                : (c <= 1791 || (c < 1869
-                  ? (c < 1810
-                    ? c == 1808
-                    : c <= 1839)
-                  : (c <= 1957 || c == 1969))))))))
-          : (c <= 2026 || (c < 2482
-            ? (c < 2208
-              ? (c < 2088
-                ? (c < 2048
-                  ? (c < 2042
-                    ? (c >= 2036 && c <= 2037)
-                    : c <= 2042)
-                  : (c <= 2069 || (c < 2084
-                    ? c == 2074
-                    : c <= 2084)))
-                : (c <= 2088 || (c < 2160
-                  ? (c < 2144
-                    ? (c >= 2112 && c <= 2136)
-                    : c <= 2154)
-                  : (c <= 2183 || (c >= 2185 && c <= 2190)))))
-              : (c <= 2249 || (c < 2417
-                ? (c < 2384
-                  ? (c < 2365
-                    ? (c >= 2308 && c <= 2361)
-                    : c <= 2365)
-                  : (c <= 2384 || (c >= 2392 && c <= 2401)))
-                : (c <= 2432 || (c < 2451
-                  ? (c < 2447
-                    ? (c >= 2437 && c <= 2444)
-                    : c <= 2448)
-                  : (c <= 2472 || (c >= 2474 && c <= 2480)))))))
-            : (c <= 2482 || (c < 2579
-              ? (c < 2527
-                ? (c < 2510
-                  ? (c < 2493
-                    ? (c >= 2486 && c <= 2489)
-                    : c <= 2493)
-                  : (c <= 2510 || (c >= 2524 && c <= 2525)))
-                : (c <= 2529 || (c < 2565
-                  ? (c < 2556
-                    ? (c >= 2544 && c <= 2545)
-                    : c <= 2556)
-                  : (c <= 2570 || (c >= 2575 && c <= 2576)))))
-              : (c <= 2600 || (c < 2649
-                ? (c < 2613
-                  ? (c < 2610
-                    ? (c >= 2602 && c <= 2608)
-                    : c <= 2611)
-                  : (c <= 2614 || (c >= 2616 && c <= 2617)))
-                : (c <= 2652 || (c < 2693
-                  ? (c < 2674
-                    ? c == 2654
-                    : c <= 2676)
-                  : (c <= 2701 || (c >= 2703 && c <= 2705)))))))))))
-        : (c <= 2728 || (c < 3242
-          ? (c < 2962
-            ? (c < 2858
-              ? (c < 2784
-                ? (c < 2741
-                  ? (c < 2738
-                    ? (c >= 2730 && c <= 2736)
-                    : c <= 2739)
-                  : (c <= 2745 || (c < 2768
-                    ? c == 2749
-                    : c <= 2768)))
-                : (c <= 2785 || (c < 2831
-                  ? (c < 2821
-                    ? c == 2809
-                    : c <= 2828)
-                  : (c <= 2832 || (c >= 2835 && c <= 2856)))))
-              : (c <= 2864 || (c < 2911
-                ? (c < 2877
-                  ? (c < 2869
-                    ? (c >= 2866 && c <= 2867)
-                    : c <= 2873)
-                  : (c <= 2877 || (c >= 2908 && c <= 2909)))
-                : (c <= 2913 || (c < 2949
-                  ? (c < 2947
-                    ? c == 2929
-                    : c <= 2947)
-                  : (c <= 2954 || (c >= 2958 && c <= 2960)))))))
-            : (c <= 2965 || (c < 3090
-              ? (c < 2984
-                ? (c < 2974
-                  ? (c < 2972
-                    ? (c >= 2969 && c <= 2970)
-                    : c <= 2972)
-                  : (c <= 2975 || (c >= 2979 && c <= 2980)))
-                : (c <= 2986 || (c < 3077
-                  ? (c < 3024
+                  : (c <= 1366 || (c < 1376
+                    ? c == 1369
+                    : c <= 1416)))
+                : (c <= 1514 || (c < 1646
+                  ? (c < 1568
+                    ? (c >= 1519 && c <= 1522)
+                    : c <= 1610)
+                  : (c <= 1647 || (c >= 1649 && c <= 1747)))))
+              : (c <= 1749 || (c < 1808
+                ? (c < 1786
+                  ? (c < 1774
+                    ? (c >= 1765 && c <= 1766)
+                    : c <= 1775)
+                  : (c <= 1788 || c == 1791))
+                : (c <= 1808 || (c < 1969
+                  ? (c < 1869
+                    ? (c >= 1810 && c <= 1839)
+                    : c <= 1957)
+                  : (c <= 1969 || (c >= 1994 && c <= 2026)))))))))
+          : (c <= 2037 || (c < 2486
+            ? (c < 2308
+              ? (c < 2112
+                ? (c < 2074
+                  ? (c < 2048
+                    ? c == 2042
+                    : c <= 2069)
+                  : (c <= 2074 || (c < 2088
+                    ? c == 2084
+                    : c <= 2088)))
+                : (c <= 2136 || (c < 2185
+                  ? (c < 2160
+                    ? (c >= 2144 && c <= 2154)
+                    : c <= 2183)
+                  : (c <= 2190 || (c >= 2208 && c <= 2249)))))
+              : (c <= 2361 || (c < 2437
+                ? (c < 2392
+                  ? (c < 2384
+                    ? c == 2365
+                    : c <= 2384)
+                  : (c <= 2401 || (c >= 2417 && c <= 2432)))
+                : (c <= 2444 || (c < 2474
+                  ? (c < 2451
+                    ? (c >= 2447 && c <= 2448)
+                    : c <= 2472)
+                  : (c <= 2480 || c == 2482))))))
+            : (c <= 2489 || (c < 2610
+              ? (c < 2556
+                ? (c < 2524
+                  ? (c < 2510
+                    ? c == 2493
+                    : c <= 2510)
+                  : (c <= 2525 || (c < 2544
+                    ? (c >= 2527 && c <= 2529)
+                    : c <= 2545)))
+                : (c <= 2556 || (c < 2579
+                  ? (c < 2575
+                    ? (c >= 2565 && c <= 2570)
+                    : c <= 2576)
+                  : (c <= 2600 || (c >= 2602 && c <= 2608)))))
+              : (c <= 2611 || (c < 2674
+                ? (c < 2649
+                  ? (c < 2616
+                    ? (c >= 2613 && c <= 2614)
+                    : c <= 2617)
+                  : (c <= 2652 || c == 2654))
+                : (c <= 2676 || (c < 2707
+                  ? (c < 2703
+                    ? (c >= 2693 && c <= 2701)
+                    : c <= 2705)
+                  : (c <= 2728 || (c >= 2730 && c <= 2736)))))))))))
+        : (c <= 2739 || (c < 3293
+          ? (c < 2972
+            ? (c < 2869
+              ? (c < 2821
+                ? (c < 2768
+                  ? (c < 2749
+                    ? (c >= 2741 && c <= 2745)
+                    : c <= 2749)
+                  : (c <= 2768 || (c < 2809
+                    ? (c >= 2784 && c <= 2785)
+                    : c <= 2809)))
+                : (c <= 2828 || (c < 2858
+                  ? (c < 2835
+                    ? (c >= 2831 && c <= 2832)
+                    : c <= 2856)
+                  : (c <= 2864 || (c >= 2866 && c <= 2867)))))
+              : (c <= 2873 || (c < 2947
+                ? (c < 2911
+                  ? (c < 2908
+                    ? c == 2877
+                    : c <= 2909)
+                  : (c <= 2913 || c == 2929))
+                : (c <= 2947 || (c < 2962
+                  ? (c < 2958
+                    ? (c >= 2949 && c <= 2954)
+                    : c <= 2960)
+                  : (c <= 2965 || (c >= 2969 && c <= 2970)))))))
+            : (c <= 2972 || (c < 3160
+              ? (c < 3077
+                ? (c < 2984
+                  ? (c < 2979
+                    ? (c >= 2974 && c <= 2975)
+                    : c <= 2980)
+                  : (c <= 2986 || (c < 3024
                     ? (c >= 2990 && c <= 3001)
-                    : c <= 3024)
-                  : (c <= 3084 || (c >= 3086 && c <= 3088)))))
-              : (c <= 3112 || (c < 3168
-                ? (c < 3160
-                  ? (c < 3133
-                    ? (c >= 3114 && c <= 3129)
-                    : c <= 3133)
-                  : (c <= 3162 || c == 3165))
-                : (c <= 3169 || (c < 3214
-                  ? (c < 3205
-                    ? c == 3200
-                    : c <= 3212)
-                  : (c <= 3216 || (c >= 3218 && c <= 3240)))))))))
-          : (c <= 3251 || (c < 3648
-            ? (c < 3412
-              ? (c < 3332
-                ? (c < 3293
-                  ? (c < 3261
-                    ? (c >= 3253 && c <= 3257)
-                    : c <= 3261)
-                  : (c <= 3294 || (c < 3313
+                    : c <= 3024)))
+                : (c <= 3084 || (c < 3114
+                  ? (c < 3090
+                    ? (c >= 3086 && c <= 3088)
+                    : c <= 3112)
+                  : (c <= 3129 || c == 3133))))
+              : (c <= 3162 || (c < 3214
+                ? (c < 3200
+                  ? (c < 3168
+                    ? c == 3165
+                    : c <= 3169)
+                  : (c <= 3200 || (c >= 3205 && c <= 3212)))
+                : (c <= 3216 || (c < 3253
+                  ? (c < 3242
+                    ? (c >= 3218 && c <= 3240)
+                    : c <= 3251)
+                  : (c <= 3257 || c == 3261))))))))
+          : (c <= 3294 || (c < 3718
+            ? (c < 3461
+              ? (c < 3389
+                ? (c < 3332
+                  ? (c < 3313
                     ? (c >= 3296 && c <= 3297)
-                    : c <= 3314)))
-                : (c <= 3340 || (c < 3389
-                  ? (c < 3346
+                    : c <= 3314)
+                  : (c <= 3340 || (c < 3346
                     ? (c >= 3342 && c <= 3344)
-                    : c <= 3386)
-                  : (c <= 3389 || c == 3406))))
-              : (c <= 3414 || (c < 3507
-                ? (c < 3461
-                  ? (c < 3450
-                    ? (c >= 3423 && c <= 3425)
-                    : c <= 3455)
-                  : (c <= 3478 || (c >= 3482 && c <= 3505)))
-                : (c <= 3515 || (c < 3585
-                  ? (c < 3520
-                    ? c == 3517
-                    : c <= 3526)
-                  : (c <= 3632 || c == 3634))))))
-            : (c <= 3654 || (c < 3782
-              ? (c < 3749
-                ? (c < 3718
-                  ? (c < 3716
-                    ? (c >= 3713 && c <= 3714)
-                    : c <= 3716)
-                  : (c <= 3722 || (c >= 3724 && c <= 3747)))
-                : (c <= 3749 || (c < 3773
-                  ? (c < 3762
-                    ? (c >= 3751 && c <= 3760)
-                    : c <= 3762)
-                  : (c <= 3773 || (c >= 3776 && c <= 3780)))))
-              : (c <= 3782 || (c < 3976
-                ? (c < 3904
-                  ? (c < 3840
-                    ? (c >= 3804 && c <= 3807)
-                    : c <= 3840)
-                  : (c <= 3911 || (c >= 3913 && c <= 3948)))
-                : (c <= 3980 || (c < 4176
-                  ? (c < 4159
-                    ? (c >= 4096 && c <= 4138)
-                    : c <= 4159)
-                  : (c <= 4181 || (c >= 4186 && c <= 4189)))))))))))))
-      : (c <= 4193 || (c < 8134
-        ? (c < 6176
-          ? (c < 4808
-            ? (c < 4688
-              ? (c < 4295
-                ? (c < 4213
-                  ? (c < 4206
-                    ? (c >= 4197 && c <= 4198)
-                    : c <= 4208)
-                  : (c <= 4225 || (c < 4256
+                    : c <= 3386)))
+                : (c <= 3389 || (c < 3423
+                  ? (c < 3412
+                    ? c == 3406
+                    : c <= 3414)
+                  : (c <= 3425 || (c >= 3450 && c <= 3455)))))
+              : (c <= 3478 || (c < 3585
+                ? (c < 3517
+                  ? (c < 3507
+                    ? (c >= 3482 && c <= 3505)
+                    : c <= 3515)
+                  : (c <= 3517 || (c >= 3520 && c <= 3526)))
+                : (c <= 3632 || (c < 3713
+                  ? (c < 3648
+                    ? c == 3634
+                    : c <= 3654)
+                  : (c <= 3714 || c == 3716))))))
+            : (c <= 3722 || (c < 3904
+              ? (c < 3773
+                ? (c < 3751
+                  ? (c < 3749
+                    ? (c >= 3724 && c <= 3747)
+                    : c <= 3749)
+                  : (c <= 3760 || c == 3762))
+                : (c <= 3773 || (c < 3804
+                  ? (c < 3782
+                    ? (c >= 3776 && c <= 3780)
+                    : c <= 3782)
+                  : (c <= 3807 || c == 3840))))
+              : (c <= 3911 || (c < 4176
+                ? (c < 4096
+                  ? (c < 3976
+                    ? (c >= 3913 && c <= 3948)
+                    : c <= 3980)
+                  : (c <= 4138 || c == 4159))
+                : (c <= 4181 || (c < 4197
+                  ? (c < 4193
+                    ? (c >= 4186 && c <= 4189)
+                    : c <= 4193)
+                  : (c <= 4198 || (c >= 4206 && c <= 4208)))))))))))))
+      : (c <= 4225 || (c < 8182
+        ? (c < 6400
+          ? (c < 4888
+            ? (c < 4704
+              ? (c < 4348
+                ? (c < 4295
+                  ? (c < 4256
                     ? c == 4238
-                    : c <= 4293)))
-                : (c <= 4295 || (c < 4348
-                  ? (c < 4304
+                    : c <= 4293)
+                  : (c <= 4295 || (c < 4304
                     ? c == 4301
-                    : c <= 4346)
-                  : (c <= 4680 || (c >= 4682 && c <= 4685)))))
-              : (c <= 4694 || (c < 4752
-                ? (c < 4704
-                  ? (c < 4698
-                    ? c == 4696
-                    : c <= 4701)
-                  : (c <= 4744 || (c >= 4746 && c <= 4749)))
-                : (c <= 4784 || (c < 4800
-                  ? (c < 4792
-                    ? (c >= 4786 && c <= 4789)
-                    : c <= 4798)
-                  : (c <= 4800 || (c >= 4802 && c <= 4805)))))))
-            : (c <= 4822 || (c < 5792
-              ? (c < 5024
-                ? (c < 4888
-                  ? (c < 4882
-                    ? (c >= 4824 && c <= 4880)
-                    : c <= 4885)
-                  : (c <= 4954 || (c >= 4992 && c <= 5007)))
-                : (c <= 5109 || (c < 5743
-                  ? (c < 5121
-                    ? (c >= 5112 && c <= 5117)
-                    : c <= 5740)
-                  : (c <= 5759 || (c >= 5761 && c <= 5786)))))
-              : (c <= 5866 || (c < 5984
-                ? (c < 5919
-                  ? (c < 5888
-                    ? (c >= 5870 && c <= 5880)
-                    : c <= 5905)
-                  : (c <= 5937 || (c >= 5952 && c <= 5969)))
-                : (c <= 5996 || (c < 6103
-                  ? (c < 6016
-                    ? (c >= 5998 && c <= 6000)
-                    : c <= 6067)
-                  : (c <= 6103 || c == 6108))))))))
-          : (c <= 6264 || (c < 7312
-            ? (c < 6823
-              ? (c < 6512
-                ? (c < 6320
-                  ? (c < 6314
-                    ? (c >= 6272 && c <= 6312)
-                    : c <= 6314)
-                  : (c <= 6389 || (c < 6480
-                    ? (c >= 6400 && c <= 6430)
-                    : c <= 6509)))
-                : (c <= 6516 || (c < 6656
-                  ? (c < 6576
-                    ? (c >= 6528 && c <= 6571)
-                    : c <= 6601)
-                  : (c <= 6678 || (c >= 6688 && c <= 6740)))))
-              : (c <= 6823 || (c < 7098
-                ? (c < 7043
-                  ? (c < 6981
-                    ? (c >= 6917 && c <= 6963)
-                    : c <= 6988)
-                  : (c <= 7072 || (c >= 7086 && c <= 7087)))
-                : (c <= 7141 || (c < 7258
-                  ? (c < 7245
-                    ? (c >= 7168 && c <= 7203)
-                    : c <= 7247)
-                  : (c <= 7293 || (c >= 7296 && c <= 7304)))))))
-            : (c <= 7354 || (c < 8008
-              ? (c < 7418
-                ? (c < 7406
-                  ? (c < 7401
-                    ? (c >= 7357 && c <= 7359)
-                    : c <= 7404)
-                  : (c <= 7411 || (c >= 7413 && c <= 7414)))
-                : (c <= 7418 || (c < 7960
-                  ? (c < 7680
-                    ? (c >= 7424 && c <= 7615)
-                    : c <= 7957)
-                  : (c <= 7965 || (c >= 7968 && c <= 8005)))))
-              : (c <= 8013 || (c < 8031
-                ? (c < 8027
+                    : c <= 4346)))
+                : (c <= 4680 || (c < 4696
+                  ? (c < 4688
+                    ? (c >= 4682 && c <= 4685)
+                    : c <= 4694)
+                  : (c <= 4696 || (c >= 4698 && c <= 4701)))))
+              : (c <= 4744 || (c < 4800
+                ? (c < 4786
+                  ? (c < 4752
+                    ? (c >= 4746 && c <= 4749)
+                    : c <= 4784)
+                  : (c <= 4789 || (c >= 4792 && c <= 4798)))
+                : (c <= 4800 || (c < 4824
+                  ? (c < 4808
+                    ? (c >= 4802 && c <= 4805)
+                    : c <= 4822)
+                  : (c <= 4880 || (c >= 4882 && c <= 4885)))))))
+            : (c <= 4954 || (c < 5952
+              ? (c < 5761
+                ? (c < 5112
+                  ? (c < 5024
+                    ? (c >= 4992 && c <= 5007)
+                    : c <= 5109)
+                  : (c <= 5117 || (c < 5743
+                    ? (c >= 5121 && c <= 5740)
+                    : c <= 5759)))
+                : (c <= 5786 || (c < 5888
+                  ? (c < 5870
+                    ? (c >= 5792 && c <= 5866)
+                    : c <= 5880)
+                  : (c <= 5905 || (c >= 5919 && c <= 5937)))))
+              : (c <= 5969 || (c < 6108
+                ? (c < 6016
+                  ? (c < 5998
+                    ? (c >= 5984 && c <= 5996)
+                    : c <= 6000)
+                  : (c <= 6067 || c == 6103))
+                : (c <= 6108 || (c < 6314
+                  ? (c < 6272
+                    ? (c >= 6176 && c <= 6264)
+                    : c <= 6312)
+                  : (c <= 6314 || (c >= 6320 && c <= 6389)))))))))
+          : (c <= 6430 || (c < 7413
+            ? (c < 7086
+              ? (c < 6688
+                ? (c < 6528
+                  ? (c < 6512
+                    ? (c >= 6480 && c <= 6509)
+                    : c <= 6516)
+                  : (c <= 6571 || (c < 6656
+                    ? (c >= 6576 && c <= 6601)
+                    : c <= 6678)))
+                : (c <= 6740 || (c < 6981
+                  ? (c < 6917
+                    ? c == 6823
+                    : c <= 6963)
+                  : (c <= 6988 || (c >= 7043 && c <= 7072)))))
+              : (c <= 7087 || (c < 7296
+                ? (c < 7245
+                  ? (c < 7168
+                    ? (c >= 7098 && c <= 7141)
+                    : c <= 7203)
+                  : (c <= 7247 || (c >= 7258 && c <= 7293)))
+                : (c <= 7304 || (c < 7401
+                  ? (c < 7357
+                    ? (c >= 7312 && c <= 7354)
+                    : c <= 7359)
+                  : (c <= 7404 || (c >= 7406 && c <= 7411)))))))
+            : (c <= 7414 || (c < 8031
+              ? (c < 8008
+                ? (c < 7680
+                  ? (c < 7424
+                    ? c == 7418
+                    : c <= 7615)
+                  : (c <= 7957 || (c < 7968
+                    ? (c >= 7960 && c <= 7965)
+                    : c <= 8005)))
+                : (c <= 8013 || (c < 8027
                   ? (c < 8025
                     ? (c >= 8016 && c <= 8023)
                     : c <= 8025)
-                  : (c <= 8027 || c == 8029))
-                : (c <= 8061 || (c < 8126
+                  : (c <= 8027 || c == 8029))))
+              : (c <= 8061 || (c < 8134
+                ? (c < 8126
                   ? (c < 8118
                     ? (c >= 8064 && c <= 8116)
                     : c <= 8124)
-                  : (c <= 8126 || (c >= 8130 && c <= 8132)))))))))))
-        : (c <= 8140 || (c < 12337
-          ? (c < 8544
-            ? (c < 8458
-              ? (c < 8305
-                ? (c < 8160
+                  : (c <= 8126 || (c >= 8130 && c <= 8132)))
+                : (c <= 8140 || (c < 8160
                   ? (c < 8150
                     ? (c >= 8144 && c <= 8147)
                     : c <= 8155)
-                  : (c <= 8172 || (c < 8182
-                    ? (c >= 8178 && c <= 8180)
-                    : c <= 8188)))
-                : (c <= 8305 || (c < 8450
-                  ? (c < 8336
-                    ? c == 8319
-                    : c <= 8348)
-                  : (c <= 8450 || c == 8455))))
-              : (c <= 8467 || (c < 8488
-                ? (c < 8484
+                  : (c <= 8172 || (c >= 8178 && c <= 8180)))))))))))
+        : (c <= 8188 || (c < 12549
+          ? (c < 11559
+            ? (c < 8488
+              ? (c < 8458
+                ? (c < 8336
+                  ? (c < 8319
+                    ? c == 8305
+                    : c <= 8319)
+                  : (c <= 8348 || (c < 8455
+                    ? c == 8450
+                    : c <= 8455)))
+                : (c <= 8467 || (c < 8484
                   ? (c < 8472
                     ? c == 8469
                     : c <= 8477)
-                  : (c <= 8484 || c == 8486))
-                : (c <= 8488 || (c < 8517
+                  : (c <= 8484 || c == 8486))))
+              : (c <= 8488 || (c < 8544
+                ? (c < 8517
                   ? (c < 8508
                     ? (c >= 8490 && c <= 8505)
                     : c <= 8511)
-                  : (c <= 8521 || c == 8526))))))
-            : (c <= 8584 || (c < 11680
-              ? (c < 11559
-                ? (c < 11506
+                  : (c <= 8521 || c == 8526))
+                : (c <= 8584 || (c < 11506
                   ? (c < 11499
                     ? (c >= 11264 && c <= 11492)
                     : c <= 11502)
-                  : (c <= 11507 || (c >= 11520 && c <= 11557)))
-                : (c <= 11559 || (c < 11631
+                  : (c <= 11507 || (c >= 11520 && c <= 11557)))))))
+            : (c <= 11559 || (c < 11728
+              ? (c < 11688
+                ? (c < 11631
                   ? (c < 11568
                     ? c == 11565
                     : c <= 11623)
-                  : (c <= 11631 || (c >= 11648 && c <= 11670)))))
-              : (c <= 11686 || (c < 11720
-                ? (c < 11704
-                  ? (c < 11696
-                    ? (c >= 11688 && c <= 11694)
-                    : c <= 11702)
-                  : (c <= 11710 || (c >= 11712 && c <= 11718)))
-                : (c <= 11726 || (c < 12293
-                  ? (c < 11736
-                    ? (c >= 11728 && c <= 11734)
-                    : c <= 11742)
-                  : (c <= 12295 || (c >= 12321 && c <= 12329)))))))))
-          : (c <= 12341 || (c < 42891
-            ? (c < 19968
-              ? (c < 12549
-                ? (c < 12445
-                  ? (c < 12353
-                    ? (c >= 12344 && c <= 12348)
-                    : c <= 12438)
-                  : (c <= 12447 || (c < 12540
-                    ? (c >= 12449 && c <= 12538)
-                    : c <= 12543)))
-                : (c <= 12591 || (c < 12784
+                  : (c <= 11631 || (c < 11680
+                    ? (c >= 11648 && c <= 11670)
+                    : c <= 11686)))
+                : (c <= 11694 || (c < 11712
+                  ? (c < 11704
+                    ? (c >= 11696 && c <= 11702)
+                    : c <= 11710)
+                  : (c <= 11718 || (c >= 11720 && c <= 11726)))))
+              : (c <= 11734 || (c < 12344
+                ? (c < 12321
+                  ? (c < 12293
+                    ? (c >= 11736 && c <= 11742)
+                    : c <= 12295)
+                  : (c <= 12329 || (c >= 12337 && c <= 12341)))
+                : (c <= 12348 || (c < 12449
+                  ? (c < 12445
+                    ? (c >= 12353 && c <= 12438)
+                    : c <= 12447)
+                  : (c <= 12538 || (c >= 12540 && c <= 12543)))))))))
+          : (c <= 12591 || (c < 43015
+            ? (c < 42623
+              ? (c < 42192
+                ? (c < 12784
                   ? (c < 12704
                     ? (c >= 12593 && c <= 12686)
                     : c <= 12735)
-                  : (c <= 12799 || (c >= 13312 && c <= 19903)))))
-              : (c <= 42124 || (c < 42560
-                ? (c < 42512
-                  ? (c < 42240
-                    ? (c >= 42192 && c <= 42237)
-                    : c <= 42508)
-                  : (c <= 42527 || (c >= 42538 && c <= 42539)))
-                : (c <= 42606 || (c < 42775
-                  ? (c < 42656
-                    ? (c >= 42623 && c <= 42653)
-                    : c <= 42735)
-                  : (c <= 42783 || (c >= 42786 && c <= 42888)))))))
-            : (c <= 42954 || (c < 43250
-              ? (c < 43011
-                ? (c < 42965
-                  ? (c < 42963
-                    ? (c >= 42960 && c <= 42961)
-                    : c <= 42963)
-                  : (c <= 42969 || (c >= 42994 && c <= 43009)))
-                : (c <= 43013 || (c < 43072
-                  ? (c < 43020
-                    ? (c >= 43015 && c <= 43018)
-                    : c <= 43042)
-                  : (c <= 43123 || (c >= 43138 && c <= 43187)))))
-              : (c <= 43255 || (c < 43360
-                ? (c < 43274
-                  ? (c < 43261
-                    ? c == 43259
-                    : c <= 43262)
-                  : (c <= 43301 || (c >= 43312 && c <= 43334)))
-                : (c <= 43388 || (c < 43488
-                  ? (c < 43471
-                    ? (c >= 43396 && c <= 43442)
-                    : c <= 43471)
-                  : (c <= 43492 || (c >= 43494 && c <= 43503)))))))))))))))
-    : (c <= 43518 || (c < 70727
-      ? (c < 66956
-        ? (c < 64914
-          ? (c < 43868
-            ? (c < 43714
-              ? (c < 43646
-                ? (c < 43588
-                  ? (c < 43584
-                    ? (c >= 43520 && c <= 43560)
-                    : c <= 43586)
-                  : (c <= 43595 || (c < 43642
-                    ? (c >= 43616 && c <= 43638)
-                    : c <= 43642)))
-                : (c <= 43695 || (c < 43705
+                  : (c <= 12799 || (c < 19968
+                    ? (c >= 13312 && c <= 19903)
+                    : c <= 42124)))
+                : (c <= 42237 || (c < 42538
+                  ? (c < 42512
+                    ? (c >= 42240 && c <= 42508)
+                    : c <= 42527)
+                  : (c <= 42539 || (c >= 42560 && c <= 42606)))))
+              : (c <= 42653 || (c < 42960
+                ? (c < 42786
+                  ? (c < 42775
+                    ? (c >= 42656 && c <= 42735)
+                    : c <= 42783)
+                  : (c <= 42888 || (c >= 42891 && c <= 42954)))
+                : (c <= 42961 || (c < 42994
+                  ? (c < 42965
+                    ? c == 42963
+                    : c <= 42969)
+                  : (c <= 43009 || (c >= 43011 && c <= 43013)))))))
+            : (c <= 43018 || (c < 43396
+              ? (c < 43259
+                ? (c < 43138
+                  ? (c < 43072
+                    ? (c >= 43020 && c <= 43042)
+                    : c <= 43123)
+                  : (c <= 43187 || (c >= 43250 && c <= 43255)))
+                : (c <= 43259 || (c < 43312
+                  ? (c < 43274
+                    ? (c >= 43261 && c <= 43262)
+                    : c <= 43301)
+                  : (c <= 43334 || (c >= 43360 && c <= 43388)))))
+              : (c <= 43442 || (c < 43520
+                ? (c < 43494
+                  ? (c < 43488
+                    ? c == 43471
+                    : c <= 43492)
+                  : (c <= 43503 || (c >= 43514 && c <= 43518)))
+                : (c <= 43560 || (c < 43616
+                  ? (c < 43588
+                    ? (c >= 43584 && c <= 43586)
+                    : c <= 43595)
+                  : (c <= 43638 || c == 43642))))))))))))))
+    : (c <= 43695 || (c < 71236
+      ? (c < 67424
+        ? (c < 65149
+          ? (c < 64112
+            ? (c < 43793
+              ? (c < 43739
+                ? (c < 43705
                   ? (c < 43701
                     ? c == 43697
                     : c <= 43702)
-                  : (c <= 43709 || c == 43712))))
-              : (c <= 43714 || (c < 43785
-                ? (c < 43762
-                  ? (c < 43744
-                    ? (c >= 43739 && c <= 43741)
-                    : c <= 43754)
-                  : (c <= 43764 || (c >= 43777 && c <= 43782)))
-                : (c <= 43790 || (c < 43816
-                  ? (c < 43808
-                    ? (c >= 43793 && c <= 43798)
-                    : c <= 43814)
-                  : (c <= 43822 || (c >= 43824 && c <= 43866)))))))
-            : (c <= 43881 || (c < 64287
-              ? (c < 63744
-                ? (c < 55216
-                  ? (c < 44032
-                    ? (c >= 43888 && c <= 44002)
-                    : c <= 55203)
-                  : (c <= 55238 || (c >= 55243 && c <= 55291)))
-                : (c <= 64109 || (c < 64275
-                  ? (c < 64256
-                    ? (c >= 64112 && c <= 64217)
-                    : c <= 64262)
-                  : (c <= 64279 || c == 64285))))
-              : (c <= 64296 || (c < 64323
-                ? (c < 64318
-                  ? (c < 64312
-                    ? (c >= 64298 && c <= 64310)
-                    : c <= 64316)
-                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
-                : (c <= 64324 || (c < 64612
-                  ? (c < 64467
-                    ? (c >= 64326 && c <= 64433)
-                    : c <= 64605)
-                  : (c <= 64829 || (c >= 64848 && c <= 64911)))))))))
-          : (c <= 64967 || (c < 65599
-            ? (c < 65382
-              ? (c < 65147
-                ? (c < 65139
-                  ? (c < 65137
-                    ? (c >= 65008 && c <= 65017)
-                    : c <= 65137)
-                  : (c <= 65139 || (c < 65145
-                    ? c == 65143
-                    : c <= 65145)))
-                : (c <= 65147 || (c < 65313
-                  ? (c < 65151
-                    ? c == 65149
-                    : c <= 65276)
-                  : (c <= 65338 || (c >= 65345 && c <= 65370)))))
-              : (c <= 65437 || (c < 65498
-                ? (c < 65482
-                  ? (c < 65474
-                    ? (c >= 65440 && c <= 65470)
-                    : c <= 65479)
-                  : (c <= 65487 || (c >= 65490 && c <= 65495)))
-                : (c <= 65500 || (c < 65576
-                  ? (c < 65549
-                    ? (c >= 65536 && c <= 65547)
-                    : c <= 65574)
-                  : (c <= 65594 || (c >= 65596 && c <= 65597)))))))
-            : (c <= 65613 || (c < 66464
-              ? (c < 66208
-                ? (c < 65856
-                  ? (c < 65664
-                    ? (c >= 65616 && c <= 65629)
-                    : c <= 65786)
-                  : (c <= 65908 || (c >= 66176 && c <= 66204)))
-                : (c <= 66256 || (c < 66384
-                  ? (c < 66349
-                    ? (c >= 66304 && c <= 66335)
-                    : c <= 66378)
-                  : (c <= 66421 || (c >= 66432 && c <= 66461)))))
-              : (c <= 66499 || (c < 66776
-                ? (c < 66560
-                  ? (c < 66513
+                  : (c <= 43709 || (c < 43714
+                    ? c == 43712
+                    : c <= 43714)))
+                : (c <= 43741 || (c < 43777
+                  ? (c < 43762
+                    ? (c >= 43744 && c <= 43754)
+                    : c <= 43764)
+                  : (c <= 43782 || (c >= 43785 && c <= 43790)))))
+              : (c <= 43798 || (c < 43888
+                ? (c < 43824
+                  ? (c < 43816
+                    ? (c >= 43808 && c <= 43814)
+                    : c <= 43822)
+                  : (c <= 43866 || (c >= 43868 && c <= 43881)))
+                : (c <= 44002 || (c < 55243
+                  ? (c < 55216
+                    ? (c >= 44032 && c <= 55203)
+                    : c <= 55238)
+                  : (c <= 55291 || (c >= 63744 && c <= 64109)))))))
+            : (c <= 64217 || (c < 64467
+              ? (c < 64312
+                ? (c < 64285
+                  ? (c < 64275
+                    ? (c >= 64256 && c <= 64262)
+                    : c <= 64279)
+                  : (c <= 64285 || (c < 64298
+                    ? (c >= 64287 && c <= 64296)
+                    : c <= 64310)))
+                : (c <= 64316 || (c < 64323
+                  ? (c < 64320
+                    ? c == 64318
+                    : c <= 64321)
+                  : (c <= 64324 || (c >= 64326 && c <= 64433)))))
+              : (c <= 64605 || (c < 65137
+                ? (c < 64914
+                  ? (c < 64848
+                    ? (c >= 64612 && c <= 64829)
+                    : c <= 64911)
+                  : (c <= 64967 || (c >= 65008 && c <= 65017)))
+                : (c <= 65137 || (c < 65145
+                  ? (c < 65143
+                    ? c == 65139
+                    : c <= 65143)
+                  : (c <= 65145 || c == 65147))))))))
+          : (c <= 65149 || (c < 66349
+            ? (c < 65549
+              ? (c < 65474
+                ? (c < 65345
+                  ? (c < 65313
+                    ? (c >= 65151 && c <= 65276)
+                    : c <= 65338)
+                  : (c <= 65370 || (c < 65440
+                    ? (c >= 65382 && c <= 65437)
+                    : c <= 65470)))
+                : (c <= 65479 || (c < 65498
+                  ? (c < 65490
+                    ? (c >= 65482 && c <= 65487)
+                    : c <= 65495)
+                  : (c <= 65500 || (c >= 65536 && c <= 65547)))))
+              : (c <= 65574 || (c < 65664
+                ? (c < 65599
+                  ? (c < 65596
+                    ? (c >= 65576 && c <= 65594)
+                    : c <= 65597)
+                  : (c <= 65613 || (c >= 65616 && c <= 65629)))
+                : (c <= 65786 || (c < 66208
+                  ? (c < 66176
+                    ? (c >= 65856 && c <= 65908)
+                    : c <= 66204)
+                  : (c <= 66256 || (c >= 66304 && c <= 66335)))))))
+            : (c <= 66378 || (c < 66928
+              ? (c < 66560
+                ? (c < 66464
+                  ? (c < 66432
+                    ? (c >= 66384 && c <= 66421)
+                    : c <= 66461)
+                  : (c <= 66499 || (c < 66513
                     ? (c >= 66504 && c <= 66511)
-                    : c <= 66517)
-                  : (c <= 66717 || (c >= 66736 && c <= 66771)))
-                : (c <= 66811 || (c < 66928
-                  ? (c < 66864
-                    ? (c >= 66816 && c <= 66855)
-                    : c <= 66915)
-                  : (c <= 66938 || (c >= 66940 && c <= 66954)))))))))))
-        : (c <= 66962 || (c < 68864
-          ? (c < 67828
-            ? (c < 67506
-              ? (c < 67072
-                ? (c < 66979
-                  ? (c < 66967
-                    ? (c >= 66964 && c <= 66965)
-                    : c <= 66977)
-                  : (c <= 66993 || (c < 67003
+                    : c <= 66517)))
+                : (c <= 66717 || (c < 66816
+                  ? (c < 66776
+                    ? (c >= 66736 && c <= 66771)
+                    : c <= 66811)
+                  : (c <= 66855 || (c >= 66864 && c <= 66915)))))
+              : (c <= 66938 || (c < 66979
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c >= 66967 && c <= 66977)))
+                : (c <= 66993 || (c < 67072
+                  ? (c < 67003
                     ? (c >= 66995 && c <= 67001)
-                    : c <= 67004)))
-                : (c <= 67382 || (c < 67456
-                  ? (c < 67424
-                    ? (c >= 67392 && c <= 67413)
-                    : c <= 67431)
-                  : (c <= 67461 || (c >= 67463 && c <= 67504)))))
-              : (c <= 67514 || (c < 67644
-                ? (c < 67594
-                  ? (c < 67592
+                    : c <= 67004)
+                  : (c <= 67382 || (c >= 67392 && c <= 67413)))))))))))
+        : (c <= 67431 || (c < 69635
+          ? (c < 68121
+            ? (c < 67712
+              ? (c < 67594
+                ? (c < 67506
+                  ? (c < 67463
+                    ? (c >= 67456 && c <= 67461)
+                    : c <= 67504)
+                  : (c <= 67514 || (c < 67592
                     ? (c >= 67584 && c <= 67589)
-                    : c <= 67592)
-                  : (c <= 67637 || (c >= 67639 && c <= 67640)))
-                : (c <= 67644 || (c < 67712
-                  ? (c < 67680
-                    ? (c >= 67647 && c <= 67669)
-                    : c <= 67702)
-                  : (c <= 67742 || (c >= 67808 && c <= 67826)))))))
-            : (c <= 67829 || (c < 68224
-              ? (c < 68096
-                ? (c < 67968
-                  ? (c < 67872
-                    ? (c >= 67840 && c <= 67861)
-                    : c <= 67897)
-                  : (c <= 68023 || (c >= 68030 && c <= 68031)))
-                : (c <= 68096 || (c < 68121
-                  ? (c < 68117
-                    ? (c >= 68112 && c <= 68115)
-                    : c <= 68119)
-                  : (c <= 68149 || (c >= 68192 && c <= 68220)))))
-              : (c <= 68252 || (c < 68448
-                ? (c < 68352
-                  ? (c < 68297
-                    ? (c >= 68288 && c <= 68295)
-                    : c <= 68324)
-                  : (c <= 68405 || (c >= 68416 && c <= 68437)))
-                : (c <= 68466 || (c < 68736
-                  ? (c < 68608
-                    ? (c >= 68480 && c <= 68497)
-                    : c <= 68680)
-                  : (c <= 68786 || (c >= 68800 && c <= 68850)))))))))
-          : (c <= 68899 || (c < 70106
-            ? (c < 69749
-              ? (c < 69488
-                ? (c < 69376
-                  ? (c < 69296
-                    ? (c >= 69248 && c <= 69289)
-                    : c <= 69297)
-                  : (c <= 69404 || (c < 69424
-                    ? c == 69415
-                    : c <= 69445)))
-                : (c <= 69505 || (c < 69635
-                  ? (c < 69600
-                    ? (c >= 69552 && c <= 69572)
-                    : c <= 69622)
-                  : (c <= 69687 || (c >= 69745 && c <= 69746)))))
-              : (c <= 69749 || (c < 69959
-                ? (c < 69891
-                  ? (c < 69840
-                    ? (c >= 69763 && c <= 69807)
-                    : c <= 69864)
-                  : (c <= 69926 || c == 69956))
-                : (c <= 69959 || (c < 70019
-                  ? (c < 70006
-                    ? (c >= 69968 && c <= 70002)
-                    : c <= 70006)
-                  : (c <= 70066 || (c >= 70081 && c <= 70084)))))))
-            : (c <= 70106 || (c < 70405
-              ? (c < 70280
-                ? (c < 70163
-                  ? (c < 70144
-                    ? c == 70108
-                    : c <= 70161)
-                  : (c <= 70187 || (c >= 70272 && c <= 70278)))
-                : (c <= 70280 || (c < 70303
-                  ? (c < 70287
-                    ? (c >= 70282 && c <= 70285)
-                    : c <= 70301)
-                  : (c <= 70312 || (c >= 70320 && c <= 70366)))))
-              : (c <= 70412 || (c < 70453
-                ? (c < 70442
-                  ? (c < 70419
-                    ? (c >= 70415 && c <= 70416)
-                    : c <= 70440)
-                  : (c <= 70448 || (c >= 70450 && c <= 70451)))
-                : (c <= 70457 || (c < 70493
-                  ? (c < 70480
-                    ? c == 70461
-                    : c <= 70480)
-                  : (c <= 70497 || (c >= 70656 && c <= 70708)))))))))))))
-      : (c <= 70730 || (c < 119894
-        ? (c < 73056
-          ? (c < 72001
-            ? (c < 71424
-              ? (c < 71128
-                ? (c < 70852
-                  ? (c < 70784
-                    ? (c >= 70751 && c <= 70753)
-                    : c <= 70831)
-                  : (c <= 70853 || (c < 71040
+                    : c <= 67592)))
+                : (c <= 67637 || (c < 67647
+                  ? (c < 67644
+                    ? (c >= 67639 && c <= 67640)
+                    : c <= 67644)
+                  : (c <= 67669 || (c >= 67680 && c <= 67702)))))
+              : (c <= 67742 || (c < 67968
+                ? (c < 67840
+                  ? (c < 67828
+                    ? (c >= 67808 && c <= 67826)
+                    : c <= 67829)
+                  : (c <= 67861 || (c >= 67872 && c <= 67897)))
+                : (c <= 68023 || (c < 68112
+                  ? (c < 68096
+                    ? (c >= 68030 && c <= 68031)
+                    : c <= 68096)
+                  : (c <= 68115 || (c >= 68117 && c <= 68119)))))))
+            : (c <= 68149 || (c < 68800
+              ? (c < 68416
+                ? (c < 68288
+                  ? (c < 68224
+                    ? (c >= 68192 && c <= 68220)
+                    : c <= 68252)
+                  : (c <= 68295 || (c < 68352
+                    ? (c >= 68297 && c <= 68324)
+                    : c <= 68405)))
+                : (c <= 68437 || (c < 68608
+                  ? (c < 68480
+                    ? (c >= 68448 && c <= 68466)
+                    : c <= 68497)
+                  : (c <= 68680 || (c >= 68736 && c <= 68786)))))
+              : (c <= 68850 || (c < 69415
+                ? (c < 69296
+                  ? (c < 69248
+                    ? (c >= 68864 && c <= 68899)
+                    : c <= 69289)
+                  : (c <= 69297 || (c >= 69376 && c <= 69404)))
+                : (c <= 69415 || (c < 69552
+                  ? (c < 69488
+                    ? (c >= 69424 && c <= 69445)
+                    : c <= 69505)
+                  : (c <= 69572 || (c >= 69600 && c <= 69622)))))))))
+          : (c <= 69687 || (c < 70303
+            ? (c < 70081
+              ? (c < 69956
+                ? (c < 69763
+                  ? (c < 69749
+                    ? (c >= 69745 && c <= 69746)
+                    : c <= 69749)
+                  : (c <= 69807 || (c < 69891
+                    ? (c >= 69840 && c <= 69864)
+                    : c <= 69926)))
+                : (c <= 69956 || (c < 70006
+                  ? (c < 69968
+                    ? c == 69959
+                    : c <= 70002)
+                  : (c <= 70006 || (c >= 70019 && c <= 70066)))))
+              : (c <= 70084 || (c < 70207
+                ? (c < 70144
+                  ? (c < 70108
+                    ? c == 70106
+                    : c <= 70108)
+                  : (c <= 70161 || (c >= 70163 && c <= 70187)))
+                : (c <= 70208 || (c < 70282
+                  ? (c < 70280
+                    ? (c >= 70272 && c <= 70278)
+                    : c <= 70280)
+                  : (c <= 70285 || (c >= 70287 && c <= 70301)))))))
+            : (c <= 70312 || (c < 70493
+              ? (c < 70442
+                ? (c < 70415
+                  ? (c < 70405
+                    ? (c >= 70320 && c <= 70366)
+                    : c <= 70412)
+                  : (c <= 70416 || (c >= 70419 && c <= 70440)))
+                : (c <= 70448 || (c < 70461
+                  ? (c < 70453
+                    ? (c >= 70450 && c <= 70451)
+                    : c <= 70457)
+                  : (c <= 70461 || c == 70480))))
+              : (c <= 70497 || (c < 70852
+                ? (c < 70751
+                  ? (c < 70727
+                    ? (c >= 70656 && c <= 70708)
+                    : c <= 70730)
+                  : (c <= 70753 || (c >= 70784 && c <= 70831)))
+                : (c <= 70853 || (c < 71128
+                  ? (c < 71040
                     ? c == 70855
-                    : c <= 71086)))
-                : (c <= 71131 || (c < 71296
-                  ? (c < 71236
-                    ? (c >= 71168 && c <= 71215)
-                    : c <= 71236)
-                  : (c <= 71338 || c == 71352))))
-              : (c <= 71450 || (c < 71945
-                ? (c < 71840
-                  ? (c < 71680
+                    : c <= 71086)
+                  : (c <= 71131 || (c >= 71168 && c <= 71215)))))))))))))
+      : (c <= 71236 || (c < 119973
+        ? (c < 73728
+          ? (c < 72272
+            ? (c < 71960
+              ? (c < 71840
+                ? (c < 71424
+                  ? (c < 71352
+                    ? (c >= 71296 && c <= 71338)
+                    : c <= 71352)
+                  : (c <= 71450 || (c < 71680
                     ? (c >= 71488 && c <= 71494)
-                    : c <= 71723)
-                  : (c <= 71903 || (c >= 71935 && c <= 71942)))
-                : (c <= 71945 || (c < 71960
-                  ? (c < 71957
-                    ? (c >= 71948 && c <= 71955)
-                    : c <= 71958)
-                  : (c <= 71983 || c == 71999))))))
-            : (c <= 72001 || (c < 72349
-              ? (c < 72192
-                ? (c < 72161
-                  ? (c < 72106
-                    ? (c >= 72096 && c <= 72103)
-                    : c <= 72144)
-                  : (c <= 72161 || c == 72163))
-                : (c <= 72192 || (c < 72272
-                  ? (c < 72250
-                    ? (c >= 72203 && c <= 72242)
-                    : c <= 72250)
-                  : (c <= 72272 || (c >= 72284 && c <= 72329)))))
-              : (c <= 72349 || (c < 72818
-                ? (c < 72714
-                  ? (c < 72704
-                    ? (c >= 72368 && c <= 72440)
-                    : c <= 72712)
-                  : (c <= 72750 || c == 72768))
-                : (c <= 72847 || (c < 72971
-                  ? (c < 72968
-                    ? (c >= 72960 && c <= 72966)
-                    : c <= 72969)
-                  : (c <= 73008 || c == 73030))))))))
-          : (c <= 73061 || (c < 93952
-            ? (c < 82944
-              ? (c < 73728
-                ? (c < 73112
-                  ? (c < 73066
-                    ? (c >= 73063 && c <= 73064)
-                    : c <= 73097)
-                  : (c <= 73112 || (c < 73648
-                    ? (c >= 73440 && c <= 73458)
-                    : c <= 73648)))
-                : (c <= 74649 || (c < 77712
+                    : c <= 71723)))
+                : (c <= 71903 || (c < 71948
+                  ? (c < 71945
+                    ? (c >= 71935 && c <= 71942)
+                    : c <= 71945)
+                  : (c <= 71955 || (c >= 71957 && c <= 71958)))))
+              : (c <= 71983 || (c < 72161
+                ? (c < 72096
+                  ? (c < 72001
+                    ? c == 71999
+                    : c <= 72001)
+                  : (c <= 72103 || (c >= 72106 && c <= 72144)))
+                : (c <= 72161 || (c < 72203
+                  ? (c < 72192
+                    ? c == 72163
+                    : c <= 72192)
+                  : (c <= 72242 || c == 72250))))))
+            : (c <= 72272 || (c < 73030
+              ? (c < 72768
+                ? (c < 72368
+                  ? (c < 72349
+                    ? (c >= 72284 && c <= 72329)
+                    : c <= 72349)
+                  : (c <= 72440 || (c < 72714
+                    ? (c >= 72704 && c <= 72712)
+                    : c <= 72750)))
+                : (c <= 72768 || (c < 72968
+                  ? (c < 72960
+                    ? (c >= 72818 && c <= 72847)
+                    : c <= 72966)
+                  : (c <= 72969 || (c >= 72971 && c <= 73008)))))
+              : (c <= 73030 || (c < 73440
+                ? (c < 73066
+                  ? (c < 73063
+                    ? (c >= 73056 && c <= 73061)
+                    : c <= 73064)
+                  : (c <= 73097 || c == 73112))
+                : (c <= 73458 || (c < 73490
+                  ? (c < 73476
+                    ? c == 73474
+                    : c <= 73488)
+                  : (c <= 73523 || c == 73648))))))))
+          : (c <= 74649 || (c < 94208
+            ? (c < 92928
+              ? (c < 82944
+                ? (c < 77712
                   ? (c < 74880
                     ? (c >= 74752 && c <= 74862)
                     : c <= 75075)
-                  : (c <= 77808 || (c >= 77824 && c <= 78894)))))
-              : (c <= 83526 || (c < 92928
-                ? (c < 92784
+                  : (c <= 77808 || (c < 78913
+                    ? (c >= 77824 && c <= 78895)
+                    : c <= 78918)))
+                : (c <= 83526 || (c < 92784
                   ? (c < 92736
                     ? (c >= 92160 && c <= 92728)
                     : c <= 92766)
-                  : (c <= 92862 || (c >= 92880 && c <= 92909)))
-                : (c <= 92975 || (c < 93053
+                  : (c <= 92862 || (c >= 92880 && c <= 92909)))))
+              : (c <= 92975 || (c < 93952
+                ? (c < 93053
                   ? (c < 93027
                     ? (c >= 92992 && c <= 92995)
                     : c <= 93047)
-                  : (c <= 93071 || (c >= 93760 && c <= 93823)))))))
-            : (c <= 94026 || (c < 110589
-              ? (c < 94208
-                ? (c < 94176
+                  : (c <= 93071 || (c >= 93760 && c <= 93823)))
+                : (c <= 94026 || (c < 94176
                   ? (c < 94099
                     ? c == 94032
                     : c <= 94111)
-                  : (c <= 94177 || c == 94179))
-                : (c <= 100343 || (c < 110576
+                  : (c <= 94177 || c == 94179))))))
+            : (c <= 100343 || (c < 110948
+              ? (c < 110589
+                ? (c < 110576
                   ? (c < 101632
                     ? (c >= 100352 && c <= 101589)
                     : c <= 101640)
-                  : (c <= 110579 || (c >= 110581 && c <= 110587)))))
-              : (c <= 110590 || (c < 113664
-                ? (c < 110948
-                  ? (c < 110928
+                  : (c <= 110579 || (c >= 110581 && c <= 110587)))
+                : (c <= 110590 || (c < 110928
+                  ? (c < 110898
                     ? (c >= 110592 && c <= 110882)
-                    : c <= 110930)
-                  : (c <= 110951 || (c >= 110960 && c <= 111355)))
-                : (c <= 113770 || (c < 113808
-                  ? (c < 113792
-                    ? (c >= 113776 && c <= 113788)
-                    : c <= 113800)
-                  : (c <= 113817 || (c >= 119808 && c <= 119892)))))))))))
-        : (c <= 119964 || (c < 125259
-          ? (c < 120572
-            ? (c < 120086
-              ? (c < 119995
-                ? (c < 119973
-                  ? (c < 119970
-                    ? (c >= 119966 && c <= 119967)
-                    : c <= 119970)
-                  : (c <= 119974 || (c < 119982
+                    : c <= 110898)
+                  : (c <= 110930 || c == 110933))))
+              : (c <= 110951 || (c < 113808
+                ? (c < 113776
+                  ? (c < 113664
+                    ? (c >= 110960 && c <= 111355)
+                    : c <= 113770)
+                  : (c <= 113788 || (c >= 113792 && c <= 113800)))
+                : (c <= 113817 || (c < 119966
+                  ? (c < 119894
+                    ? (c >= 119808 && c <= 119892)
+                    : c <= 119964)
+                  : (c <= 119967 || c == 119970))))))))))
+        : (c <= 119974 || (c < 126464
+          ? (c < 120656
+            ? (c < 120128
+              ? (c < 120071
+                ? (c < 119995
+                  ? (c < 119982
                     ? (c >= 119977 && c <= 119980)
-                    : c <= 119993)))
-                : (c <= 119995 || (c < 120071
-                  ? (c < 120005
+                    : c <= 119993)
+                  : (c <= 119995 || (c < 120005
                     ? (c >= 119997 && c <= 120003)
-                    : c <= 120069)
-                  : (c <= 120074 || (c >= 120077 && c <= 120084)))))
-              : (c <= 120092 || (c < 120138
-                ? (c < 120128
-                  ? (c < 120123
-                    ? (c >= 120094 && c <= 120121)
-                    : c <= 120126)
-                  : (c <= 120132 || c == 120134))
-                : (c <= 120144 || (c < 120514
-                  ? (c < 120488
-                    ? (c >= 120146 && c <= 120485)
-                    : c <= 120512)
-                  : (c <= 120538 || (c >= 120540 && c <= 120570)))))))
-            : (c <= 120596 || (c < 123191
-              ? (c < 120714
-                ? (c < 120656
-                  ? (c < 120630
-                    ? (c >= 120598 && c <= 120628)
-                    : c <= 120654)
-                  : (c <= 120686 || (c >= 120688 && c <= 120712)))
-                : (c <= 120744 || (c < 122624
-                  ? (c < 120772
-                    ? (c >= 120746 && c <= 120770)
-                    : c <= 120779)
-                  : (c <= 122654 || (c >= 123136 && c <= 123180)))))
-              : (c <= 123197 || (c < 124904
-                ? (c < 123584
-                  ? (c < 123536
-                    ? c == 123214
-                    : c <= 123565)
-                  : (c <= 123627 || (c >= 124896 && c <= 124902)))
-                : (c <= 124907 || (c < 124928
-                  ? (c < 124912
-                    ? (c >= 124909 && c <= 124910)
-                    : c <= 124926)
-                  : (c <= 125124 || (c >= 125184 && c <= 125251)))))))))
-          : (c <= 125259 || (c < 126559
-            ? (c < 126535
-              ? (c < 126505
-                ? (c < 126497
-                  ? (c < 126469
-                    ? (c >= 126464 && c <= 126467)
-                    : c <= 126495)
-                  : (c <= 126498 || (c < 126503
-                    ? c == 126500
-                    : c <= 126503)))
-                : (c <= 126514 || (c < 126523
-                  ? (c < 126521
-                    ? (c >= 126516 && c <= 126519)
-                    : c <= 126521)
-                  : (c <= 126523 || c == 126530))))
-              : (c <= 126535 || (c < 126548
-                ? (c < 126541
-                  ? (c < 126539
-                    ? c == 126537
-                    : c <= 126539)
-                  : (c <= 126543 || (c >= 126545 && c <= 126546)))
-                : (c <= 126548 || (c < 126555
-                  ? (c < 126553
-                    ? c == 126551
-                    : c <= 126553)
-                  : (c <= 126555 || c == 126557))))))
-            : (c <= 126559 || (c < 126625
-              ? (c < 126580
-                ? (c < 126567
-                  ? (c < 126564
-                    ? (c >= 126561 && c <= 126562)
-                    : c <= 126564)
-                  : (c <= 126570 || (c >= 126572 && c <= 126578)))
-                : (c <= 126583 || (c < 126592
-                  ? (c < 126590
-                    ? (c >= 126585 && c <= 126588)
-                    : c <= 126590)
-                  : (c <= 126601 || (c >= 126603 && c <= 126619)))))
-              : (c <= 126627 || (c < 177984
-                ? (c < 131072
-                  ? (c < 126635
-                    ? (c >= 126629 && c <= 126633)
-                    : c <= 126651)
-                  : (c <= 173791 || (c >= 173824 && c <= 177976)))
-                : (c <= 178205 || (c < 194560
-                  ? (c < 183984
-                    ? (c >= 178208 && c <= 183969)
-                    : c <= 191456)
-                  : (c <= 195101 || (c >= 196608 && c <= 201546)))))))))))))))));
+                    : c <= 120069)))
+                : (c <= 120074 || (c < 120094
+                  ? (c < 120086
+                    ? (c >= 120077 && c <= 120084)
+                    : c <= 120092)
+                  : (c <= 120121 || (c >= 120123 && c <= 120126)))))
+              : (c <= 120132 || (c < 120514
+                ? (c < 120146
+                  ? (c < 120138
+                    ? c == 120134
+                    : c <= 120144)
+                  : (c <= 120485 || (c >= 120488 && c <= 120512)))
+                : (c <= 120538 || (c < 120598
+                  ? (c < 120572
+                    ? (c >= 120540 && c <= 120570)
+                    : c <= 120596)
+                  : (c <= 120628 || (c >= 120630 && c <= 120654)))))))
+            : (c <= 120686 || (c < 123536
+              ? (c < 122661
+                ? (c < 120746
+                  ? (c < 120714
+                    ? (c >= 120688 && c <= 120712)
+                    : c <= 120744)
+                  : (c <= 120770 || (c < 122624
+                    ? (c >= 120772 && c <= 120779)
+                    : c <= 122654)))
+                : (c <= 122666 || (c < 123191
+                  ? (c < 123136
+                    ? (c >= 122928 && c <= 122989)
+                    : c <= 123180)
+                  : (c <= 123197 || c == 123214))))
+              : (c <= 123565 || (c < 124909
+                ? (c < 124896
+                  ? (c < 124112
+                    ? (c >= 123584 && c <= 123627)
+                    : c <= 124139)
+                  : (c <= 124902 || (c >= 124904 && c <= 124907)))
+                : (c <= 124910 || (c < 125184
+                  ? (c < 124928
+                    ? (c >= 124912 && c <= 124926)
+                    : c <= 125124)
+                  : (c <= 125251 || c == 125259))))))))
+          : (c <= 126467 || (c < 126561
+            ? (c < 126537
+              ? (c < 126516
+                ? (c < 126500
+                  ? (c < 126497
+                    ? (c >= 126469 && c <= 126495)
+                    : c <= 126498)
+                  : (c <= 126500 || (c < 126505
+                    ? c == 126503
+                    : c <= 126514)))
+                : (c <= 126519 || (c < 126530
+                  ? (c < 126523
+                    ? c == 126521
+                    : c <= 126523)
+                  : (c <= 126530 || c == 126535))))
+              : (c <= 126537 || (c < 126551
+                ? (c < 126545
+                  ? (c < 126541
+                    ? c == 126539
+                    : c <= 126543)
+                  : (c <= 126546 || c == 126548))
+                : (c <= 126551 || (c < 126557
+                  ? (c < 126555
+                    ? c == 126553
+                    : c <= 126555)
+                  : (c <= 126557 || c == 126559))))))
+            : (c <= 126562 || (c < 126629
+              ? (c < 126585
+                ? (c < 126572
+                  ? (c < 126567
+                    ? c == 126564
+                    : c <= 126570)
+                  : (c <= 126578 || (c >= 126580 && c <= 126583)))
+                : (c <= 126588 || (c < 126603
+                  ? (c < 126592
+                    ? c == 126590
+                    : c <= 126601)
+                  : (c <= 126619 || (c >= 126625 && c <= 126627)))))
+              : (c <= 126633 || (c < 178208
+                ? (c < 173824
+                  ? (c < 131072
+                    ? (c >= 126635 && c <= 126651)
+                    : c <= 173791)
+                  : (c <= 177977 || (c >= 177984 && c <= 178205)))
+                : (c <= 183969 || (c < 196608
+                  ? (c < 194560
+                    ? (c >= 183984 && c <= 191456)
+                    : c <= 195101)
+                  : (c <= 201546 || (c >= 201552 && c <= 205743)))))))))))))))));
 }
 
 static inline bool sym_identifier_character_set_2(int32_t c) {
-  return (c < 43514
-    ? (c < 4193
-      ? (c < 2707
+  return (c < 43642
+    ? (c < 4206
+      ? (c < 2730
         ? (c < 1994
           ? (c < 910
             ? (c < 736
@@ -5711,1194 +5728,291 @@ static inline bool sym_identifier_character_set_2(int32_t c) {
                     ? (c >= 2437 && c <= 2444)
                     : c <= 2448)
                   : (c <= 2472 || (c >= 2474 && c <= 2480)))))))
-            : (c <= 2482 || (c < 2579
-              ? (c < 2527
+            : (c <= 2482 || (c < 2602
+              ? (c < 2544
                 ? (c < 2510
                   ? (c < 2493
                     ? (c >= 2486 && c <= 2489)
                     : c <= 2493)
-                  : (c <= 2510 || (c >= 2524 && c <= 2525)))
-                : (c <= 2529 || (c < 2565
-                  ? (c < 2556
-                    ? (c >= 2544 && c <= 2545)
-                    : c <= 2556)
-                  : (c <= 2570 || (c >= 2575 && c <= 2576)))))
-              : (c <= 2600 || (c < 2649
-                ? (c < 2613
-                  ? (c < 2610
-                    ? (c >= 2602 && c <= 2608)
-                    : c <= 2611)
-                  : (c <= 2614 || (c >= 2616 && c <= 2617)))
-                : (c <= 2652 || (c < 2693
-                  ? (c < 2674
-                    ? c == 2654
-                    : c <= 2676)
-                  : (c <= 2701 || (c >= 2703 && c <= 2705)))))))))))
-        : (c <= 2728 || (c < 3242
-          ? (c < 2962
-            ? (c < 2858
-              ? (c < 2784
-                ? (c < 2741
-                  ? (c < 2738
-                    ? (c >= 2730 && c <= 2736)
-                    : c <= 2739)
-                  : (c <= 2745 || (c < 2768
-                    ? c == 2749
-                    : c <= 2768)))
-                : (c <= 2785 || (c < 2831
-                  ? (c < 2821
-                    ? c == 2809
-                    : c <= 2828)
-                  : (c <= 2832 || (c >= 2835 && c <= 2856)))))
-              : (c <= 2864 || (c < 2911
-                ? (c < 2877
-                  ? (c < 2869
-                    ? (c >= 2866 && c <= 2867)
-                    : c <= 2873)
-                  : (c <= 2877 || (c >= 2908 && c <= 2909)))
-                : (c <= 2913 || (c < 2949
-                  ? (c < 2947
-                    ? c == 2929
-                    : c <= 2947)
-                  : (c <= 2954 || (c >= 2958 && c <= 2960)))))))
-            : (c <= 2965 || (c < 3090
-              ? (c < 2984
-                ? (c < 2974
-                  ? (c < 2972
-                    ? (c >= 2969 && c <= 2970)
-                    : c <= 2972)
-                  : (c <= 2975 || (c >= 2979 && c <= 2980)))
-                : (c <= 2986 || (c < 3077
-                  ? (c < 3024
-                    ? (c >= 2990 && c <= 3001)
-                    : c <= 3024)
-                  : (c <= 3084 || (c >= 3086 && c <= 3088)))))
-              : (c <= 3112 || (c < 3168
-                ? (c < 3160
-                  ? (c < 3133
-                    ? (c >= 3114 && c <= 3129)
-                    : c <= 3133)
-                  : (c <= 3162 || c == 3165))
-                : (c <= 3169 || (c < 3214
-                  ? (c < 3205
-                    ? c == 3200
-                    : c <= 3212)
-                  : (c <= 3216 || (c >= 3218 && c <= 3240)))))))))
-          : (c <= 3251 || (c < 3648
-            ? (c < 3412
-              ? (c < 3332
-                ? (c < 3293
-                  ? (c < 3261
-                    ? (c >= 3253 && c <= 3257)
-                    : c <= 3261)
-                  : (c <= 3294 || (c < 3313
-                    ? (c >= 3296 && c <= 3297)
-                    : c <= 3314)))
-                : (c <= 3340 || (c < 3389
-                  ? (c < 3346
-                    ? (c >= 3342 && c <= 3344)
-                    : c <= 3386)
-                  : (c <= 3389 || c == 3406))))
-              : (c <= 3414 || (c < 3507
-                ? (c < 3461
-                  ? (c < 3450
-                    ? (c >= 3423 && c <= 3425)
-                    : c <= 3455)
-                  : (c <= 3478 || (c >= 3482 && c <= 3505)))
-                : (c <= 3515 || (c < 3585
-                  ? (c < 3520
-                    ? c == 3517
-                    : c <= 3526)
-                  : (c <= 3632 || c == 3634))))))
-            : (c <= 3654 || (c < 3782
-              ? (c < 3749
-                ? (c < 3718
-                  ? (c < 3716
-                    ? (c >= 3713 && c <= 3714)
-                    : c <= 3716)
-                  : (c <= 3722 || (c >= 3724 && c <= 3747)))
-                : (c <= 3749 || (c < 3773
-                  ? (c < 3762
-                    ? (c >= 3751 && c <= 3760)
-                    : c <= 3762)
-                  : (c <= 3773 || (c >= 3776 && c <= 3780)))))
-              : (c <= 3782 || (c < 3976
-                ? (c < 3904
-                  ? (c < 3840
-                    ? (c >= 3804 && c <= 3807)
-                    : c <= 3840)
-                  : (c <= 3911 || (c >= 3913 && c <= 3948)))
-                : (c <= 3980 || (c < 4176
-                  ? (c < 4159
-                    ? (c >= 4096 && c <= 4138)
-                    : c <= 4159)
-                  : (c <= 4181 || (c >= 4186 && c <= 4189)))))))))))))
-      : (c <= 4193 || (c < 8134
-        ? (c < 6176
-          ? (c < 4808
-            ? (c < 4688
-              ? (c < 4295
-                ? (c < 4213
-                  ? (c < 4206
-                    ? (c >= 4197 && c <= 4198)
-                    : c <= 4208)
-                  : (c <= 4225 || (c < 4256
-                    ? c == 4238
-                    : c <= 4293)))
-                : (c <= 4295 || (c < 4348
-                  ? (c < 4304
-                    ? c == 4301
-                    : c <= 4346)
-                  : (c <= 4680 || (c >= 4682 && c <= 4685)))))
-              : (c <= 4694 || (c < 4752
-                ? (c < 4704
-                  ? (c < 4698
-                    ? c == 4696
-                    : c <= 4701)
-                  : (c <= 4744 || (c >= 4746 && c <= 4749)))
-                : (c <= 4784 || (c < 4800
-                  ? (c < 4792
-                    ? (c >= 4786 && c <= 4789)
-                    : c <= 4798)
-                  : (c <= 4800 || (c >= 4802 && c <= 4805)))))))
-            : (c <= 4822 || (c < 5792
-              ? (c < 5024
-                ? (c < 4888
-                  ? (c < 4882
-                    ? (c >= 4824 && c <= 4880)
-                    : c <= 4885)
-                  : (c <= 4954 || (c >= 4992 && c <= 5007)))
-                : (c <= 5109 || (c < 5743
-                  ? (c < 5121
+                  : (c <= 2510 || (c < 2527
+                    ? (c >= 2524 && c <= 2525)
+                    : c <= 2529)))
+                : (c <= 2545 || (c < 2575
+                  ? (c < 2565
+                    ? c == 2556
+                    : c <= 2570)
+                  : (c <= 2576 || (c >= 2579 && c <= 2600)))))
+              : (c <= 2608 || (c < 2654
+                ? (c < 2616
+                  ? (c < 2613
+                    ? (c >= 2610 && c <= 2611)
+                    : c <= 2614)
+                  : (c <= 2617 || (c >= 2649 && c <= 2652)))
+                : (c <= 2654 || (c < 2703
+                  ? (c < 2693
+                    ? (c >= 2674 && c <= 2676)
+                    : c <= 2701)
+                  : (c <= 2705 || (c >= 2707 && c <= 2728)))))))))))
+        : (c <= 2736 || (c < 3261
+          ? (c < 2969
+            ? (c < 2866
+              ? (c < 2809
+                ? (c < 2749
+                  ? (c < 2741
+                    ? (c >= 2738 && c <= 2739)
+                    : c <= 2745)
+                  : (c <= 2749 || (c < 2784
+                    ? c == 2768
+                    : c <= 2785)))
+                : (c <= 2809 || (c < 2835
+                  ? (c < 2831
+                    ? (c >= 2821 && c <= 2828)
+                    : c <= 2832)
+                  : (c <= 2856 || (c >= 2858 && c <= 2864)))))
+              : (c <= 2867 || (c < 2929
+                ? (c < 2908
+                  ? (c < 2877
+                    ? (c >= 2869 && c <= 2873)
+                    : c <= 2877)
+                  : (c <= 2909 || (c >= 2911 && c <= 2913)))
+                : (c <= 2929 || (c < 2958
+                  ? (c < 2949
+                    ? c == 2947
+                    : c <= 2954)
+                  : (c <= 2960 || (c >= 2962 && c <= 2965)))))))
+            : (c <= 2970 || (c < 3133
+              ? (c < 3024
+                ? (c < 2979
+                  ? (c < 2974
+                    ? c == 2972
+                    : c <= 2975)
+                  : (c <= 2980 || (c < 2990
+                    ? (c >= 2984 && c <= 2986)
+                    : c <= 3001)))
+                : (c <= 3024 || (c < 3090
+                  ? (c < 3086
+                    ? (c >= 3077 && c <= 3084)
+                    : c <= 3088)
+                  : (c <= 3112 || (c >= 3114 && c <= 3129)))))
+              : (c <= 3133 || (c < 3205
+                ? (c < 3168
+                  ? (c < 3165
+                    ? (c >= 3160 && c <= 3162)
+                    : c <= 3165)
+                  : (c <= 3169 || c == 3200))
+                : (c <= 3212 || (c < 3242
+                  ? (c < 3218
+                    ? (c >= 3214 && c <= 3216)
+                    : c <= 3240)
+                  : (c <= 3251 || (c >= 3253 && c <= 3257)))))))))
+          : (c <= 3261 || (c < 3716
+            ? (c < 3450
+              ? (c < 3346
+                ? (c < 3313
+                  ? (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3297)
+                  : (c <= 3314 || (c < 3342
+                    ? (c >= 3332 && c <= 3340)
+                    : c <= 3344)))
+                : (c <= 3386 || (c < 3412
+                  ? (c < 3406
+                    ? c == 3389
+                    : c <= 3406)
+                  : (c <= 3414 || (c >= 3423 && c <= 3425)))))
+              : (c <= 3455 || (c < 3520
+                ? (c < 3507
+                  ? (c < 3482
+                    ? (c >= 3461 && c <= 3478)
+                    : c <= 3505)
+                  : (c <= 3515 || c == 3517))
+                : (c <= 3526 || (c < 3648
+                  ? (c < 3634
+                    ? (c >= 3585 && c <= 3632)
+                    : c <= 3634)
+                  : (c <= 3654 || (c >= 3713 && c <= 3714)))))))
+            : (c <= 3716 || (c < 3840
+              ? (c < 3762
+                ? (c < 3749
+                  ? (c < 3724
+                    ? (c >= 3718 && c <= 3722)
+                    : c <= 3747)
+                  : (c <= 3749 || (c >= 3751 && c <= 3760)))
+                : (c <= 3762 || (c < 3782
+                  ? (c < 3776
+                    ? c == 3773
+                    : c <= 3780)
+                  : (c <= 3782 || (c >= 3804 && c <= 3807)))))
+              : (c <= 3840 || (c < 4159
+                ? (c < 3976
+                  ? (c < 3913
+                    ? (c >= 3904 && c <= 3911)
+                    : c <= 3948)
+                  : (c <= 3980 || (c >= 4096 && c <= 4138)))
+                : (c <= 4159 || (c < 4193
+                  ? (c < 4186
+                    ? (c >= 4176 && c <= 4181)
+                    : c <= 4189)
+                  : (c <= 4193 || (c >= 4197 && c <= 4198)))))))))))))
+      : (c <= 4208 || (c < 8178
+        ? (c < 6320
+          ? (c < 4882
+            ? (c < 4698
+              ? (c < 4304
+                ? (c < 4256
+                  ? (c < 4238
+                    ? (c >= 4213 && c <= 4225)
+                    : c <= 4238)
+                  : (c <= 4293 || (c < 4301
+                    ? c == 4295
+                    : c <= 4301)))
+                : (c <= 4346 || (c < 4688
+                  ? (c < 4682
+                    ? (c >= 4348 && c <= 4680)
+                    : c <= 4685)
+                  : (c <= 4694 || c == 4696))))
+              : (c <= 4701 || (c < 4792
+                ? (c < 4752
+                  ? (c < 4746
+                    ? (c >= 4704 && c <= 4744)
+                    : c <= 4749)
+                  : (c <= 4784 || (c >= 4786 && c <= 4789)))
+                : (c <= 4798 || (c < 4808
+                  ? (c < 4802
+                    ? c == 4800
+                    : c <= 4805)
+                  : (c <= 4822 || (c >= 4824 && c <= 4880)))))))
+            : (c <= 4885 || (c < 5919
+              ? (c < 5743
+                ? (c < 5024
+                  ? (c < 4992
+                    ? (c >= 4888 && c <= 4954)
+                    : c <= 5007)
+                  : (c <= 5109 || (c < 5121
                     ? (c >= 5112 && c <= 5117)
-                    : c <= 5740)
-                  : (c <= 5759 || (c >= 5761 && c <= 5786)))))
-              : (c <= 5866 || (c < 5984
-                ? (c < 5919
-                  ? (c < 5888
-                    ? (c >= 5870 && c <= 5880)
-                    : c <= 5905)
-                  : (c <= 5937 || (c >= 5952 && c <= 5969)))
-                : (c <= 5996 || (c < 6103
-                  ? (c < 6016
-                    ? (c >= 5998 && c <= 6000)
-                    : c <= 6067)
-                  : (c <= 6103 || c == 6108))))))))
-          : (c <= 6264 || (c < 7312
-            ? (c < 6823
-              ? (c < 6512
-                ? (c < 6320
-                  ? (c < 6314
-                    ? (c >= 6272 && c <= 6312)
-                    : c <= 6314)
-                  : (c <= 6389 || (c < 6480
+                    : c <= 5740)))
+                : (c <= 5759 || (c < 5870
+                  ? (c < 5792
+                    ? (c >= 5761 && c <= 5786)
+                    : c <= 5866)
+                  : (c <= 5880 || (c >= 5888 && c <= 5905)))))
+              : (c <= 5937 || (c < 6103
+                ? (c < 5998
+                  ? (c < 5984
+                    ? (c >= 5952 && c <= 5969)
+                    : c <= 5996)
+                  : (c <= 6000 || (c >= 6016 && c <= 6067)))
+                : (c <= 6103 || (c < 6272
+                  ? (c < 6176
+                    ? c == 6108
+                    : c <= 6264)
+                  : (c <= 6312 || c == 6314))))))))
+          : (c <= 6389 || (c < 7406
+            ? (c < 7043
+              ? (c < 6656
+                ? (c < 6512
+                  ? (c < 6480
                     ? (c >= 6400 && c <= 6430)
-                    : c <= 6509)))
-                : (c <= 6516 || (c < 6656
-                  ? (c < 6576
+                    : c <= 6509)
+                  : (c <= 6516 || (c < 6576
                     ? (c >= 6528 && c <= 6571)
-                    : c <= 6601)
-                  : (c <= 6678 || (c >= 6688 && c <= 6740)))))
-              : (c <= 6823 || (c < 7098
-                ? (c < 7043
-                  ? (c < 6981
-                    ? (c >= 6917 && c <= 6963)
-                    : c <= 6988)
-                  : (c <= 7072 || (c >= 7086 && c <= 7087)))
-                : (c <= 7141 || (c < 7258
-                  ? (c < 7245
-                    ? (c >= 7168 && c <= 7203)
-                    : c <= 7247)
-                  : (c <= 7293 || (c >= 7296 && c <= 7304)))))))
-            : (c <= 7354 || (c < 8008
-              ? (c < 7418
-                ? (c < 7406
-                  ? (c < 7401
-                    ? (c >= 7357 && c <= 7359)
-                    : c <= 7404)
-                  : (c <= 7411 || (c >= 7413 && c <= 7414)))
-                : (c <= 7418 || (c < 7960
-                  ? (c < 7680
-                    ? (c >= 7424 && c <= 7615)
-                    : c <= 7957)
-                  : (c <= 7965 || (c >= 7968 && c <= 8005)))))
-              : (c <= 8013 || (c < 8031
-                ? (c < 8027
-                  ? (c < 8025
-                    ? (c >= 8016 && c <= 8023)
-                    : c <= 8025)
-                  : (c <= 8027 || c == 8029))
-                : (c <= 8061 || (c < 8126
-                  ? (c < 8118
-                    ? (c >= 8064 && c <= 8116)
-                    : c <= 8124)
-                  : (c <= 8126 || (c >= 8130 && c <= 8132)))))))))))
-        : (c <= 8140 || (c < 12337
-          ? (c < 8544
-            ? (c < 8458
-              ? (c < 8305
-                ? (c < 8160
-                  ? (c < 8150
-                    ? (c >= 8144 && c <= 8147)
-                    : c <= 8155)
-                  : (c <= 8172 || (c < 8182
-                    ? (c >= 8178 && c <= 8180)
-                    : c <= 8188)))
-                : (c <= 8305 || (c < 8450
-                  ? (c < 8336
-                    ? c == 8319
-                    : c <= 8348)
-                  : (c <= 8450 || c == 8455))))
-              : (c <= 8467 || (c < 8488
-                ? (c < 8484
-                  ? (c < 8472
-                    ? c == 8469
-                    : c <= 8477)
-                  : (c <= 8484 || c == 8486))
-                : (c <= 8488 || (c < 8517
-                  ? (c < 8508
-                    ? (c >= 8490 && c <= 8505)
-                    : c <= 8511)
-                  : (c <= 8521 || c == 8526))))))
-            : (c <= 8584 || (c < 11680
-              ? (c < 11559
-                ? (c < 11506
-                  ? (c < 11499
-                    ? (c >= 11264 && c <= 11492)
-                    : c <= 11502)
-                  : (c <= 11507 || (c >= 11520 && c <= 11557)))
-                : (c <= 11559 || (c < 11631
-                  ? (c < 11568
-                    ? c == 11565
-                    : c <= 11623)
-                  : (c <= 11631 || (c >= 11648 && c <= 11670)))))
-              : (c <= 11686 || (c < 11720
-                ? (c < 11704
+                    : c <= 6601)))
+                : (c <= 6678 || (c < 6917
+                  ? (c < 6823
+                    ? (c >= 6688 && c <= 6740)
+                    : c <= 6823)
+                  : (c <= 6963 || (c >= 6981 && c <= 6988)))))
+              : (c <= 7072 || (c < 7258
+                ? (c < 7168
+                  ? (c < 7098
+                    ? (c >= 7086 && c <= 7087)
+                    : c <= 7141)
+                  : (c <= 7203 || (c >= 7245 && c <= 7247)))
+                : (c <= 7293 || (c < 7357
+                  ? (c < 7312
+                    ? (c >= 7296 && c <= 7304)
+                    : c <= 7354)
+                  : (c <= 7359 || (c >= 7401 && c <= 7404)))))))
+            : (c <= 7411 || (c < 8029
+              ? (c < 7968
+                ? (c < 7424
+                  ? (c < 7418
+                    ? (c >= 7413 && c <= 7414)
+                    : c <= 7418)
+                  : (c <= 7615 || (c < 7960
+                    ? (c >= 7680 && c <= 7957)
+                    : c <= 7965)))
+                : (c <= 8005 || (c < 8025
+                  ? (c < 8016
+                    ? (c >= 8008 && c <= 8013)
+                    : c <= 8023)
+                  : (c <= 8025 || c == 8027))))
+              : (c <= 8029 || (c < 8130
+                ? (c < 8118
+                  ? (c < 8064
+                    ? (c >= 8031 && c <= 8061)
+                    : c <= 8116)
+                  : (c <= 8124 || c == 8126))
+                : (c <= 8132 || (c < 8150
+                  ? (c < 8144
+                    ? (c >= 8134 && c <= 8140)
+                    : c <= 8147)
+                  : (c <= 8155 || (c >= 8160 && c <= 8172)))))))))))
+        : (c <= 8180 || (c < 12540
+          ? (c < 11520
+            ? (c < 8486
+              ? (c < 8455
+                ? (c < 8319
+                  ? (c < 8305
+                    ? (c >= 8182 && c <= 8188)
+                    : c <= 8305)
+                  : (c <= 8319 || (c < 8450
+                    ? (c >= 8336 && c <= 8348)
+                    : c <= 8450)))
+                : (c <= 8455 || (c < 8472
+                  ? (c < 8469
+                    ? (c >= 8458 && c <= 8467)
+                    : c <= 8469)
+                  : (c <= 8477 || c == 8484))))
+              : (c <= 8486 || (c < 8526
+                ? (c < 8508
+                  ? (c < 8490
+                    ? c == 8488
+                    : c <= 8505)
+                  : (c <= 8511 || (c >= 8517 && c <= 8521)))
+                : (c <= 8526 || (c < 11499
+                  ? (c < 11264
+                    ? (c >= 8544 && c <= 8584)
+                    : c <= 11492)
+                  : (c <= 11502 || (c >= 11506 && c <= 11507)))))))
+            : (c <= 11557 || (c < 11720
+              ? (c < 11680
+                ? (c < 11568
+                  ? (c < 11565
+                    ? c == 11559
+                    : c <= 11565)
+                  : (c <= 11623 || (c < 11648
+                    ? c == 11631
+                    : c <= 11670)))
+                : (c <= 11686 || (c < 11704
                   ? (c < 11696
                     ? (c >= 11688 && c <= 11694)
                     : c <= 11702)
-                  : (c <= 11710 || (c >= 11712 && c <= 11718)))
-                : (c <= 11726 || (c < 12293
+                  : (c <= 11710 || (c >= 11712 && c <= 11718)))))
+              : (c <= 11726 || (c < 12337
+                ? (c < 12293
                   ? (c < 11736
                     ? (c >= 11728 && c <= 11734)
                     : c <= 11742)
-                  : (c <= 12295 || (c >= 12321 && c <= 12329)))))))))
-          : (c <= 12341 || (c < 42891
-            ? (c < 19968
-              ? (c < 12549
-                ? (c < 12445
+                  : (c <= 12295 || (c >= 12321 && c <= 12329)))
+                : (c <= 12341 || (c < 12445
                   ? (c < 12353
                     ? (c >= 12344 && c <= 12348)
                     : c <= 12438)
-                  : (c <= 12447 || (c < 12540
-                    ? (c >= 12449 && c <= 12538)
-                    : c <= 12543)))
-                : (c <= 12591 || (c < 12784
-                  ? (c < 12704
-                    ? (c >= 12593 && c <= 12686)
-                    : c <= 12735)
-                  : (c <= 12799 || (c >= 13312 && c <= 19903)))))
-              : (c <= 42124 || (c < 42560
-                ? (c < 42512
-                  ? (c < 42240
-                    ? (c >= 42192 && c <= 42237)
-                    : c <= 42508)
-                  : (c <= 42527 || (c >= 42538 && c <= 42539)))
-                : (c <= 42606 || (c < 42775
-                  ? (c < 42656
-                    ? (c >= 42623 && c <= 42653)
-                    : c <= 42735)
-                  : (c <= 42783 || (c >= 42786 && c <= 42888)))))))
-            : (c <= 42954 || (c < 43250
-              ? (c < 43011
-                ? (c < 42965
-                  ? (c < 42963
-                    ? (c >= 42960 && c <= 42961)
-                    : c <= 42963)
-                  : (c <= 42969 || (c >= 42994 && c <= 43009)))
-                : (c <= 43013 || (c < 43072
-                  ? (c < 43020
-                    ? (c >= 43015 && c <= 43018)
-                    : c <= 43042)
-                  : (c <= 43123 || (c >= 43138 && c <= 43187)))))
-              : (c <= 43255 || (c < 43360
-                ? (c < 43274
-                  ? (c < 43261
-                    ? c == 43259
-                    : c <= 43262)
-                  : (c <= 43301 || (c >= 43312 && c <= 43334)))
-                : (c <= 43388 || (c < 43488
-                  ? (c < 43471
-                    ? (c >= 43396 && c <= 43442)
-                    : c <= 43471)
-                  : (c <= 43492 || (c >= 43494 && c <= 43503)))))))))))))))
-    : (c <= 43518 || (c < 70727
-      ? (c < 66956
-        ? (c < 64914
-          ? (c < 43868
-            ? (c < 43714
-              ? (c < 43646
-                ? (c < 43588
-                  ? (c < 43584
-                    ? (c >= 43520 && c <= 43560)
-                    : c <= 43586)
-                  : (c <= 43595 || (c < 43642
-                    ? (c >= 43616 && c <= 43638)
-                    : c <= 43642)))
-                : (c <= 43695 || (c < 43705
-                  ? (c < 43701
-                    ? c == 43697
-                    : c <= 43702)
-                  : (c <= 43709 || c == 43712))))
-              : (c <= 43714 || (c < 43785
-                ? (c < 43762
-                  ? (c < 43744
-                    ? (c >= 43739 && c <= 43741)
-                    : c <= 43754)
-                  : (c <= 43764 || (c >= 43777 && c <= 43782)))
-                : (c <= 43790 || (c < 43816
-                  ? (c < 43808
-                    ? (c >= 43793 && c <= 43798)
-                    : c <= 43814)
-                  : (c <= 43822 || (c >= 43824 && c <= 43866)))))))
-            : (c <= 43881 || (c < 64287
-              ? (c < 63744
-                ? (c < 55216
-                  ? (c < 44032
-                    ? (c >= 43888 && c <= 44002)
-                    : c <= 55203)
-                  : (c <= 55238 || (c >= 55243 && c <= 55291)))
-                : (c <= 64109 || (c < 64275
-                  ? (c < 64256
-                    ? (c >= 64112 && c <= 64217)
-                    : c <= 64262)
-                  : (c <= 64279 || c == 64285))))
-              : (c <= 64296 || (c < 64323
-                ? (c < 64318
-                  ? (c < 64312
-                    ? (c >= 64298 && c <= 64310)
-                    : c <= 64316)
-                  : (c <= 64318 || (c >= 64320 && c <= 64321)))
-                : (c <= 64324 || (c < 64612
-                  ? (c < 64467
-                    ? (c >= 64326 && c <= 64433)
-                    : c <= 64605)
-                  : (c <= 64829 || (c >= 64848 && c <= 64911)))))))))
-          : (c <= 64967 || (c < 65599
-            ? (c < 65382
-              ? (c < 65147
-                ? (c < 65139
-                  ? (c < 65137
-                    ? (c >= 65008 && c <= 65017)
-                    : c <= 65137)
-                  : (c <= 65139 || (c < 65145
-                    ? c == 65143
-                    : c <= 65145)))
-                : (c <= 65147 || (c < 65313
-                  ? (c < 65151
-                    ? c == 65149
-                    : c <= 65276)
-                  : (c <= 65338 || (c >= 65345 && c <= 65370)))))
-              : (c <= 65437 || (c < 65498
-                ? (c < 65482
-                  ? (c < 65474
-                    ? (c >= 65440 && c <= 65470)
-                    : c <= 65479)
-                  : (c <= 65487 || (c >= 65490 && c <= 65495)))
-                : (c <= 65500 || (c < 65576
-                  ? (c < 65549
-                    ? (c >= 65536 && c <= 65547)
-                    : c <= 65574)
-                  : (c <= 65594 || (c >= 65596 && c <= 65597)))))))
-            : (c <= 65613 || (c < 66464
-              ? (c < 66208
-                ? (c < 65856
-                  ? (c < 65664
-                    ? (c >= 65616 && c <= 65629)
-                    : c <= 65786)
-                  : (c <= 65908 || (c >= 66176 && c <= 66204)))
-                : (c <= 66256 || (c < 66384
-                  ? (c < 66349
-                    ? (c >= 66304 && c <= 66335)
-                    : c <= 66378)
-                  : (c <= 66421 || (c >= 66432 && c <= 66461)))))
-              : (c <= 66499 || (c < 66776
-                ? (c < 66560
-                  ? (c < 66513
-                    ? (c >= 66504 && c <= 66511)
-                    : c <= 66517)
-                  : (c <= 66717 || (c >= 66736 && c <= 66771)))
-                : (c <= 66811 || (c < 66928
-                  ? (c < 66864
-                    ? (c >= 66816 && c <= 66855)
-                    : c <= 66915)
-                  : (c <= 66938 || (c >= 66940 && c <= 66954)))))))))))
-        : (c <= 66962 || (c < 68864
-          ? (c < 67828
-            ? (c < 67506
-              ? (c < 67072
-                ? (c < 66979
-                  ? (c < 66967
-                    ? (c >= 66964 && c <= 66965)
-                    : c <= 66977)
-                  : (c <= 66993 || (c < 67003
-                    ? (c >= 66995 && c <= 67001)
-                    : c <= 67004)))
-                : (c <= 67382 || (c < 67456
-                  ? (c < 67424
-                    ? (c >= 67392 && c <= 67413)
-                    : c <= 67431)
-                  : (c <= 67461 || (c >= 67463 && c <= 67504)))))
-              : (c <= 67514 || (c < 67644
-                ? (c < 67594
-                  ? (c < 67592
-                    ? (c >= 67584 && c <= 67589)
-                    : c <= 67592)
-                  : (c <= 67637 || (c >= 67639 && c <= 67640)))
-                : (c <= 67644 || (c < 67712
-                  ? (c < 67680
-                    ? (c >= 67647 && c <= 67669)
-                    : c <= 67702)
-                  : (c <= 67742 || (c >= 67808 && c <= 67826)))))))
-            : (c <= 67829 || (c < 68224
-              ? (c < 68096
-                ? (c < 67968
-                  ? (c < 67872
-                    ? (c >= 67840 && c <= 67861)
-                    : c <= 67897)
-                  : (c <= 68023 || (c >= 68030 && c <= 68031)))
-                : (c <= 68096 || (c < 68121
-                  ? (c < 68117
-                    ? (c >= 68112 && c <= 68115)
-                    : c <= 68119)
-                  : (c <= 68149 || (c >= 68192 && c <= 68220)))))
-              : (c <= 68252 || (c < 68448
-                ? (c < 68352
-                  ? (c < 68297
-                    ? (c >= 68288 && c <= 68295)
-                    : c <= 68324)
-                  : (c <= 68405 || (c >= 68416 && c <= 68437)))
-                : (c <= 68466 || (c < 68736
-                  ? (c < 68608
-                    ? (c >= 68480 && c <= 68497)
-                    : c <= 68680)
-                  : (c <= 68786 || (c >= 68800 && c <= 68850)))))))))
-          : (c <= 68899 || (c < 70106
-            ? (c < 69749
-              ? (c < 69488
-                ? (c < 69376
-                  ? (c < 69296
-                    ? (c >= 69248 && c <= 69289)
-                    : c <= 69297)
-                  : (c <= 69404 || (c < 69424
-                    ? c == 69415
-                    : c <= 69445)))
-                : (c <= 69505 || (c < 69635
-                  ? (c < 69600
-                    ? (c >= 69552 && c <= 69572)
-                    : c <= 69622)
-                  : (c <= 69687 || (c >= 69745 && c <= 69746)))))
-              : (c <= 69749 || (c < 69959
-                ? (c < 69891
-                  ? (c < 69840
-                    ? (c >= 69763 && c <= 69807)
-                    : c <= 69864)
-                  : (c <= 69926 || c == 69956))
-                : (c <= 69959 || (c < 70019
-                  ? (c < 70006
-                    ? (c >= 69968 && c <= 70002)
-                    : c <= 70006)
-                  : (c <= 70066 || (c >= 70081 && c <= 70084)))))))
-            : (c <= 70106 || (c < 70405
-              ? (c < 70280
-                ? (c < 70163
-                  ? (c < 70144
-                    ? c == 70108
-                    : c <= 70161)
-                  : (c <= 70187 || (c >= 70272 && c <= 70278)))
-                : (c <= 70280 || (c < 70303
-                  ? (c < 70287
-                    ? (c >= 70282 && c <= 70285)
-                    : c <= 70301)
-                  : (c <= 70312 || (c >= 70320 && c <= 70366)))))
-              : (c <= 70412 || (c < 70453
-                ? (c < 70442
-                  ? (c < 70419
-                    ? (c >= 70415 && c <= 70416)
-                    : c <= 70440)
-                  : (c <= 70448 || (c >= 70450 && c <= 70451)))
-                : (c <= 70457 || (c < 70493
-                  ? (c < 70480
-                    ? c == 70461
-                    : c <= 70480)
-                  : (c <= 70497 || (c >= 70656 && c <= 70708)))))))))))))
-      : (c <= 70730 || (c < 119894
-        ? (c < 73056
-          ? (c < 72001
-            ? (c < 71424
-              ? (c < 71128
-                ? (c < 70852
-                  ? (c < 70784
-                    ? (c >= 70751 && c <= 70753)
-                    : c <= 70831)
-                  : (c <= 70853 || (c < 71040
-                    ? c == 70855
-                    : c <= 71086)))
-                : (c <= 71131 || (c < 71296
-                  ? (c < 71236
-                    ? (c >= 71168 && c <= 71215)
-                    : c <= 71236)
-                  : (c <= 71338 || c == 71352))))
-              : (c <= 71450 || (c < 71945
-                ? (c < 71840
-                  ? (c < 71680
-                    ? (c >= 71488 && c <= 71494)
-                    : c <= 71723)
-                  : (c <= 71903 || (c >= 71935 && c <= 71942)))
-                : (c <= 71945 || (c < 71960
-                  ? (c < 71957
-                    ? (c >= 71948 && c <= 71955)
-                    : c <= 71958)
-                  : (c <= 71983 || c == 71999))))))
-            : (c <= 72001 || (c < 72349
-              ? (c < 72192
-                ? (c < 72161
-                  ? (c < 72106
-                    ? (c >= 72096 && c <= 72103)
-                    : c <= 72144)
-                  : (c <= 72161 || c == 72163))
-                : (c <= 72192 || (c < 72272
-                  ? (c < 72250
-                    ? (c >= 72203 && c <= 72242)
-                    : c <= 72250)
-                  : (c <= 72272 || (c >= 72284 && c <= 72329)))))
-              : (c <= 72349 || (c < 72818
-                ? (c < 72714
-                  ? (c < 72704
-                    ? (c >= 72368 && c <= 72440)
-                    : c <= 72712)
-                  : (c <= 72750 || c == 72768))
-                : (c <= 72847 || (c < 72971
-                  ? (c < 72968
-                    ? (c >= 72960 && c <= 72966)
-                    : c <= 72969)
-                  : (c <= 73008 || c == 73030))))))))
-          : (c <= 73061 || (c < 93952
-            ? (c < 82944
-              ? (c < 73728
-                ? (c < 73112
-                  ? (c < 73066
-                    ? (c >= 73063 && c <= 73064)
-                    : c <= 73097)
-                  : (c <= 73112 || (c < 73648
-                    ? (c >= 73440 && c <= 73458)
-                    : c <= 73648)))
-                : (c <= 74649 || (c < 77712
-                  ? (c < 74880
-                    ? (c >= 74752 && c <= 74862)
-                    : c <= 75075)
-                  : (c <= 77808 || (c >= 77824 && c <= 78894)))))
-              : (c <= 83526 || (c < 92928
-                ? (c < 92784
-                  ? (c < 92736
-                    ? (c >= 92160 && c <= 92728)
-                    : c <= 92766)
-                  : (c <= 92862 || (c >= 92880 && c <= 92909)))
-                : (c <= 92975 || (c < 93053
-                  ? (c < 93027
-                    ? (c >= 92992 && c <= 92995)
-                    : c <= 93047)
-                  : (c <= 93071 || (c >= 93760 && c <= 93823)))))))
-            : (c <= 94026 || (c < 110589
-              ? (c < 94208
-                ? (c < 94176
-                  ? (c < 94099
-                    ? c == 94032
-                    : c <= 94111)
-                  : (c <= 94177 || c == 94179))
-                : (c <= 100343 || (c < 110576
-                  ? (c < 101632
-                    ? (c >= 100352 && c <= 101589)
-                    : c <= 101640)
-                  : (c <= 110579 || (c >= 110581 && c <= 110587)))))
-              : (c <= 110590 || (c < 113664
-                ? (c < 110948
-                  ? (c < 110928
-                    ? (c >= 110592 && c <= 110882)
-                    : c <= 110930)
-                  : (c <= 110951 || (c >= 110960 && c <= 111355)))
-                : (c <= 113770 || (c < 113808
-                  ? (c < 113792
-                    ? (c >= 113776 && c <= 113788)
-                    : c <= 113800)
-                  : (c <= 113817 || (c >= 119808 && c <= 119892)))))))))))
-        : (c <= 119964 || (c < 125259
-          ? (c < 120572
-            ? (c < 120086
-              ? (c < 119995
-                ? (c < 119973
-                  ? (c < 119970
-                    ? (c >= 119966 && c <= 119967)
-                    : c <= 119970)
-                  : (c <= 119974 || (c < 119982
-                    ? (c >= 119977 && c <= 119980)
-                    : c <= 119993)))
-                : (c <= 119995 || (c < 120071
-                  ? (c < 120005
-                    ? (c >= 119997 && c <= 120003)
-                    : c <= 120069)
-                  : (c <= 120074 || (c >= 120077 && c <= 120084)))))
-              : (c <= 120092 || (c < 120138
-                ? (c < 120128
-                  ? (c < 120123
-                    ? (c >= 120094 && c <= 120121)
-                    : c <= 120126)
-                  : (c <= 120132 || c == 120134))
-                : (c <= 120144 || (c < 120514
-                  ? (c < 120488
-                    ? (c >= 120146 && c <= 120485)
-                    : c <= 120512)
-                  : (c <= 120538 || (c >= 120540 && c <= 120570)))))))
-            : (c <= 120596 || (c < 123191
-              ? (c < 120714
-                ? (c < 120656
-                  ? (c < 120630
-                    ? (c >= 120598 && c <= 120628)
-                    : c <= 120654)
-                  : (c <= 120686 || (c >= 120688 && c <= 120712)))
-                : (c <= 120744 || (c < 122624
-                  ? (c < 120772
-                    ? (c >= 120746 && c <= 120770)
-                    : c <= 120779)
-                  : (c <= 122654 || (c >= 123136 && c <= 123180)))))
-              : (c <= 123197 || (c < 124904
-                ? (c < 123584
-                  ? (c < 123536
-                    ? c == 123214
-                    : c <= 123565)
-                  : (c <= 123627 || (c >= 124896 && c <= 124902)))
-                : (c <= 124907 || (c < 124928
-                  ? (c < 124912
-                    ? (c >= 124909 && c <= 124910)
-                    : c <= 124926)
-                  : (c <= 125124 || (c >= 125184 && c <= 125251)))))))))
-          : (c <= 125259 || (c < 126559
-            ? (c < 126535
-              ? (c < 126505
-                ? (c < 126497
-                  ? (c < 126469
-                    ? (c >= 126464 && c <= 126467)
-                    : c <= 126495)
-                  : (c <= 126498 || (c < 126503
-                    ? c == 126500
-                    : c <= 126503)))
-                : (c <= 126514 || (c < 126523
-                  ? (c < 126521
-                    ? (c >= 126516 && c <= 126519)
-                    : c <= 126521)
-                  : (c <= 126523 || c == 126530))))
-              : (c <= 126535 || (c < 126548
-                ? (c < 126541
-                  ? (c < 126539
-                    ? c == 126537
-                    : c <= 126539)
-                  : (c <= 126543 || (c >= 126545 && c <= 126546)))
-                : (c <= 126548 || (c < 126555
-                  ? (c < 126553
-                    ? c == 126551
-                    : c <= 126553)
-                  : (c <= 126555 || c == 126557))))))
-            : (c <= 126559 || (c < 126625
-              ? (c < 126580
-                ? (c < 126567
-                  ? (c < 126564
-                    ? (c >= 126561 && c <= 126562)
-                    : c <= 126564)
-                  : (c <= 126570 || (c >= 126572 && c <= 126578)))
-                : (c <= 126583 || (c < 126592
-                  ? (c < 126590
-                    ? (c >= 126585 && c <= 126588)
-                    : c <= 126590)
-                  : (c <= 126601 || (c >= 126603 && c <= 126619)))))
-              : (c <= 126627 || (c < 177984
-                ? (c < 131072
-                  ? (c < 126635
-                    ? (c >= 126629 && c <= 126633)
-                    : c <= 126651)
-                  : (c <= 173791 || (c >= 173824 && c <= 177976)))
-                : (c <= 178205 || (c < 194560
-                  ? (c < 183984
-                    ? (c >= 178208 && c <= 183969)
-                    : c <= 191456)
-                  : (c <= 195101 || (c >= 196608 && c <= 201546)))))))))))))))));
-}
-
-static inline bool sym_identifier_character_set_3(int32_t c) {
-  return (c < 43616
-    ? (c < 3782
-      ? (c < 2748
-        ? (c < 2045
-          ? (c < 1015
-            ? (c < 710
-              ? (c < 181
-                ? (c < '_'
-                  ? (c < 'A'
-                    ? (c >= '0' && c <= '9')
-                    : c <= 'Z')
-                  : (c <= '_' || (c < 170
-                    ? (c >= 'a' && c <= 'z')
-                    : c <= 170)))
-                : (c <= 181 || (c < 192
-                  ? (c < 186
-                    ? c == 183
-                    : c <= 186)
-                  : (c <= 214 || (c < 248
-                    ? (c >= 216 && c <= 246)
-                    : c <= 705)))))
-              : (c <= 721 || (c < 891
-                ? (c < 750
-                  ? (c < 748
-                    ? (c >= 736 && c <= 740)
-                    : c <= 748)
-                  : (c <= 750 || (c < 886
-                    ? (c >= 768 && c <= 884)
-                    : c <= 887)))
-                : (c <= 893 || (c < 908
-                  ? (c < 902
-                    ? c == 895
-                    : c <= 906)
-                  : (c <= 908 || (c < 931
-                    ? (c >= 910 && c <= 929)
-                    : c <= 1013)))))))
-            : (c <= 1153 || (c < 1519
-              ? (c < 1425
-                ? (c < 1329
-                  ? (c < 1162
-                    ? (c >= 1155 && c <= 1159)
-                    : c <= 1327)
-                  : (c <= 1366 || (c < 1376
-                    ? c == 1369
-                    : c <= 1416)))
-                : (c <= 1469 || (c < 1476
-                  ? (c < 1473
-                    ? c == 1471
-                    : c <= 1474)
-                  : (c <= 1477 || (c < 1488
-                    ? c == 1479
-                    : c <= 1514)))))
-              : (c <= 1522 || (c < 1770
-                ? (c < 1646
-                  ? (c < 1568
-                    ? (c >= 1552 && c <= 1562)
-                    : c <= 1641)
-                  : (c <= 1747 || (c < 1759
-                    ? (c >= 1749 && c <= 1756)
-                    : c <= 1768)))
-                : (c <= 1788 || (c < 1869
-                  ? (c < 1808
-                    ? c == 1791
-                    : c <= 1866)
-                  : (c <= 1969 || (c < 2042
-                    ? (c >= 1984 && c <= 2037)
-                    : c <= 2042)))))))))
-          : (c <= 2045 || (c < 2558
-            ? (c < 2451
-              ? (c < 2200
-                ? (c < 2144
-                  ? (c < 2112
-                    ? (c >= 2048 && c <= 2093)
-                    : c <= 2139)
-                  : (c <= 2154 || (c < 2185
-                    ? (c >= 2160 && c <= 2183)
-                    : c <= 2190)))
-                : (c <= 2273 || (c < 2417
-                  ? (c < 2406
-                    ? (c >= 2275 && c <= 2403)
-                    : c <= 2415)
-                  : (c <= 2435 || (c < 2447
-                    ? (c >= 2437 && c <= 2444)
-                    : c <= 2448)))))
-              : (c <= 2472 || (c < 2507
-                ? (c < 2486
-                  ? (c < 2482
-                    ? (c >= 2474 && c <= 2480)
-                    : c <= 2482)
-                  : (c <= 2489 || (c < 2503
-                    ? (c >= 2492 && c <= 2500)
-                    : c <= 2504)))
-                : (c <= 2510 || (c < 2527
-                  ? (c < 2524
-                    ? c == 2519
-                    : c <= 2525)
-                  : (c <= 2531 || (c < 2556
-                    ? (c >= 2534 && c <= 2545)
-                    : c <= 2556)))))))
-            : (c <= 2558 || (c < 2635
-              ? (c < 2610
-                ? (c < 2575
-                  ? (c < 2565
-                    ? (c >= 2561 && c <= 2563)
-                    : c <= 2570)
-                  : (c <= 2576 || (c < 2602
-                    ? (c >= 2579 && c <= 2600)
-                    : c <= 2608)))
-                : (c <= 2611 || (c < 2620
-                  ? (c < 2616
-                    ? (c >= 2613 && c <= 2614)
-                    : c <= 2617)
-                  : (c <= 2620 || (c < 2631
-                    ? (c >= 2622 && c <= 2626)
-                    : c <= 2632)))))
-              : (c <= 2637 || (c < 2693
-                ? (c < 2654
-                  ? (c < 2649
-                    ? c == 2641
-                    : c <= 2652)
-                  : (c <= 2654 || (c < 2689
-                    ? (c >= 2662 && c <= 2677)
-                    : c <= 2691)))
-                : (c <= 2701 || (c < 2730
-                  ? (c < 2707
-                    ? (c >= 2703 && c <= 2705)
-                    : c <= 2728)
-                  : (c <= 2736 || (c < 2741
-                    ? (c >= 2738 && c <= 2739)
-                    : c <= 2745)))))))))))
-        : (c <= 2757 || (c < 3168
-          ? (c < 2958
-            ? (c < 2866
-              ? (c < 2809
-                ? (c < 2768
-                  ? (c < 2763
-                    ? (c >= 2759 && c <= 2761)
-                    : c <= 2765)
-                  : (c <= 2768 || (c < 2790
-                    ? (c >= 2784 && c <= 2787)
-                    : c <= 2799)))
-                : (c <= 2815 || (c < 2831
-                  ? (c < 2821
-                    ? (c >= 2817 && c <= 2819)
-                    : c <= 2828)
-                  : (c <= 2832 || (c < 2858
-                    ? (c >= 2835 && c <= 2856)
-                    : c <= 2864)))))
-              : (c <= 2867 || (c < 2908
-                ? (c < 2887
-                  ? (c < 2876
-                    ? (c >= 2869 && c <= 2873)
-                    : c <= 2884)
-                  : (c <= 2888 || (c < 2901
-                    ? (c >= 2891 && c <= 2893)
-                    : c <= 2903)))
-                : (c <= 2909 || (c < 2929
-                  ? (c < 2918
-                    ? (c >= 2911 && c <= 2915)
-                    : c <= 2927)
-                  : (c <= 2929 || (c < 2949
-                    ? (c >= 2946 && c <= 2947)
-                    : c <= 2954)))))))
-            : (c <= 2960 || (c < 3031
-              ? (c < 2984
-                ? (c < 2972
-                  ? (c < 2969
-                    ? (c >= 2962 && c <= 2965)
-                    : c <= 2970)
-                  : (c <= 2972 || (c < 2979
-                    ? (c >= 2974 && c <= 2975)
-                    : c <= 2980)))
-                : (c <= 2986 || (c < 3014
-                  ? (c < 3006
-                    ? (c >= 2990 && c <= 3001)
-                    : c <= 3010)
-                  : (c <= 3016 || (c < 3024
-                    ? (c >= 3018 && c <= 3021)
-                    : c <= 3024)))))
-              : (c <= 3031 || (c < 3132
-                ? (c < 3086
-                  ? (c < 3072
-                    ? (c >= 3046 && c <= 3055)
-                    : c <= 3084)
-                  : (c <= 3088 || (c < 3114
-                    ? (c >= 3090 && c <= 3112)
-                    : c <= 3129)))
-                : (c <= 3140 || (c < 3157
-                  ? (c < 3146
-                    ? (c >= 3142 && c <= 3144)
-                    : c <= 3149)
-                  : (c <= 3158 || (c < 3165
-                    ? (c >= 3160 && c <= 3162)
-                    : c <= 3165)))))))))
-          : (c <= 3171 || (c < 3450
-            ? (c < 3293
-              ? (c < 3242
-                ? (c < 3205
-                  ? (c < 3200
-                    ? (c >= 3174 && c <= 3183)
-                    : c <= 3203)
-                  : (c <= 3212 || (c < 3218
-                    ? (c >= 3214 && c <= 3216)
-                    : c <= 3240)))
-                : (c <= 3251 || (c < 3270
-                  ? (c < 3260
-                    ? (c >= 3253 && c <= 3257)
-                    : c <= 3268)
-                  : (c <= 3272 || (c < 3285
-                    ? (c >= 3274 && c <= 3277)
-                    : c <= 3286)))))
-              : (c <= 3294 || (c < 3346
-                ? (c < 3313
-                  ? (c < 3302
-                    ? (c >= 3296 && c <= 3299)
-                    : c <= 3311)
-                  : (c <= 3314 || (c < 3342
-                    ? (c >= 3328 && c <= 3340)
-                    : c <= 3344)))
-                : (c <= 3396 || (c < 3412
-                  ? (c < 3402
-                    ? (c >= 3398 && c <= 3400)
-                    : c <= 3406)
-                  : (c <= 3415 || (c < 3430
-                    ? (c >= 3423 && c <= 3427)
-                    : c <= 3439)))))))
-            : (c <= 3455 || (c < 3570
-              ? (c < 3520
-                ? (c < 3482
-                  ? (c < 3461
-                    ? (c >= 3457 && c <= 3459)
-                    : c <= 3478)
-                  : (c <= 3505 || (c < 3517
-                    ? (c >= 3507 && c <= 3515)
-                    : c <= 3517)))
-                : (c <= 3526 || (c < 3542
-                  ? (c < 3535
-                    ? c == 3530
-                    : c <= 3540)
-                  : (c <= 3542 || (c < 3558
-                    ? (c >= 3544 && c <= 3551)
-                    : c <= 3567)))))
-              : (c <= 3571 || (c < 3718
-                ? (c < 3664
-                  ? (c < 3648
-                    ? (c >= 3585 && c <= 3642)
-                    : c <= 3662)
-                  : (c <= 3673 || (c < 3716
-                    ? (c >= 3713 && c <= 3714)
-                    : c <= 3716)))
-                : (c <= 3722 || (c < 3751
-                  ? (c < 3749
-                    ? (c >= 3724 && c <= 3747)
-                    : c <= 3749)
-                  : (c <= 3773 || (c >= 3776 && c <= 3780)))))))))))))
-      : (c <= 3782 || (c < 8025
-        ? (c < 5888
-          ? (c < 4688
-            ? (c < 3953
-              ? (c < 3872
-                ? (c < 3804
-                  ? (c < 3792
-                    ? (c >= 3784 && c <= 3789)
-                    : c <= 3801)
-                  : (c <= 3807 || (c < 3864
-                    ? c == 3840
-                    : c <= 3865)))
-                : (c <= 3881 || (c < 3897
-                  ? (c < 3895
-                    ? c == 3893
-                    : c <= 3895)
-                  : (c <= 3897 || (c < 3913
-                    ? (c >= 3902 && c <= 3911)
-                    : c <= 3948)))))
-              : (c <= 3972 || (c < 4256
-                ? (c < 4038
-                  ? (c < 3993
-                    ? (c >= 3974 && c <= 3991)
-                    : c <= 4028)
-                  : (c <= 4038 || (c < 4176
-                    ? (c >= 4096 && c <= 4169)
-                    : c <= 4253)))
-                : (c <= 4293 || (c < 4304
-                  ? (c < 4301
-                    ? c == 4295
-                    : c <= 4301)
-                  : (c <= 4346 || (c < 4682
-                    ? (c >= 4348 && c <= 4680)
-                    : c <= 4685)))))))
-            : (c <= 4694 || (c < 4882
-              ? (c < 4786
-                ? (c < 4704
-                  ? (c < 4698
-                    ? c == 4696
-                    : c <= 4701)
-                  : (c <= 4744 || (c < 4752
-                    ? (c >= 4746 && c <= 4749)
-                    : c <= 4784)))
-                : (c <= 4789 || (c < 4802
-                  ? (c < 4800
-                    ? (c >= 4792 && c <= 4798)
-                    : c <= 4800)
-                  : (c <= 4805 || (c < 4824
-                    ? (c >= 4808 && c <= 4822)
-                    : c <= 4880)))))
-              : (c <= 4885 || (c < 5112
-                ? (c < 4969
-                  ? (c < 4957
-                    ? (c >= 4888 && c <= 4954)
-                    : c <= 4959)
-                  : (c <= 4977 || (c < 5024
-                    ? (c >= 4992 && c <= 5007)
-                    : c <= 5109)))
-                : (c <= 5117 || (c < 5761
-                  ? (c < 5743
-                    ? (c >= 5121 && c <= 5740)
-                    : c <= 5759)
-                  : (c <= 5786 || (c < 5870
-                    ? (c >= 5792 && c <= 5866)
-                    : c <= 5880)))))))))
-          : (c <= 5909 || (c < 6688
-            ? (c < 6176
-              ? (c < 6016
-                ? (c < 5984
-                  ? (c < 5952
-                    ? (c >= 5919 && c <= 5940)
-                    : c <= 5971)
-                  : (c <= 5996 || (c < 6002
-                    ? (c >= 5998 && c <= 6000)
-                    : c <= 6003)))
-                : (c <= 6099 || (c < 6112
-                  ? (c < 6108
-                    ? c == 6103
-                    : c <= 6109)
-                  : (c <= 6121 || (c < 6159
-                    ? (c >= 6155 && c <= 6157)
-                    : c <= 6169)))))
-              : (c <= 6264 || (c < 6470
-                ? (c < 6400
-                  ? (c < 6320
-                    ? (c >= 6272 && c <= 6314)
-                    : c <= 6389)
-                  : (c <= 6430 || (c < 6448
-                    ? (c >= 6432 && c <= 6443)
-                    : c <= 6459)))
-                : (c <= 6509 || (c < 6576
-                  ? (c < 6528
-                    ? (c >= 6512 && c <= 6516)
-                    : c <= 6571)
-                  : (c <= 6601 || (c < 6656
-                    ? (c >= 6608 && c <= 6618)
-                    : c <= 6683)))))))
-            : (c <= 6750 || (c < 7232
-              ? (c < 6847
-                ? (c < 6800
-                  ? (c < 6783
-                    ? (c >= 6752 && c <= 6780)
-                    : c <= 6793)
-                  : (c <= 6809 || (c < 6832
-                    ? c == 6823
-                    : c <= 6845)))
-                : (c <= 6862 || (c < 7019
-                  ? (c < 6992
-                    ? (c >= 6912 && c <= 6988)
-                    : c <= 7001)
-                  : (c <= 7027 || (c < 7168
-                    ? (c >= 7040 && c <= 7155)
-                    : c <= 7223)))))
-              : (c <= 7241 || (c < 7380
-                ? (c < 7312
-                  ? (c < 7296
-                    ? (c >= 7245 && c <= 7293)
-                    : c <= 7304)
-                  : (c <= 7354 || (c < 7376
-                    ? (c >= 7357 && c <= 7359)
-                    : c <= 7378)))
-                : (c <= 7418 || (c < 7968
-                  ? (c < 7960
-                    ? (c >= 7424 && c <= 7957)
-                    : c <= 7965)
-                  : (c <= 8005 || (c < 8016
-                    ? (c >= 8008 && c <= 8013)
-                    : c <= 8023)))))))))))
-        : (c <= 8025 || (c < 11720
-          ? (c < 8458
-            ? (c < 8178
-              ? (c < 8126
-                ? (c < 8031
-                  ? (c < 8029
-                    ? c == 8027
-                    : c <= 8029)
-                  : (c <= 8061 || (c < 8118
-                    ? (c >= 8064 && c <= 8116)
-                    : c <= 8124)))
-                : (c <= 8126 || (c < 8144
-                  ? (c < 8134
-                    ? (c >= 8130 && c <= 8132)
-                    : c <= 8140)
-                  : (c <= 8147 || (c < 8160
-                    ? (c >= 8150 && c <= 8155)
-                    : c <= 8172)))))
-              : (c <= 8180 || (c < 8336
-                ? (c < 8276
-                  ? (c < 8255
-                    ? (c >= 8182 && c <= 8188)
-                    : c <= 8256)
-                  : (c <= 8276 || (c < 8319
-                    ? c == 8305
-                    : c <= 8319)))
-                : (c <= 8348 || (c < 8421
-                  ? (c < 8417
-                    ? (c >= 8400 && c <= 8412)
-                    : c <= 8417)
-                  : (c <= 8432 || (c < 8455
-                    ? c == 8450
-                    : c <= 8455)))))))
-            : (c <= 8467 || (c < 11499
-              ? (c < 8490
-                ? (c < 8484
-                  ? (c < 8472
-                    ? c == 8469
-                    : c <= 8477)
-                  : (c <= 8484 || (c < 8488
-                    ? c == 8486
-                    : c <= 8488)))
-                : (c <= 8505 || (c < 8526
-                  ? (c < 8517
-                    ? (c >= 8508 && c <= 8511)
-                    : c <= 8521)
-                  : (c <= 8526 || (c < 11264
-                    ? (c >= 8544 && c <= 8584)
-                    : c <= 11492)))))
-              : (c <= 11507 || (c < 11647
-                ? (c < 11565
-                  ? (c < 11559
-                    ? (c >= 11520 && c <= 11557)
-                    : c <= 11559)
-                  : (c <= 11565 || (c < 11631
-                    ? (c >= 11568 && c <= 11623)
-                    : c <= 11631)))
-                : (c <= 11670 || (c < 11696
-                  ? (c < 11688
-                    ? (c >= 11680 && c <= 11686)
-                    : c <= 11694)
-                  : (c <= 11702 || (c < 11712
-                    ? (c >= 11704 && c <= 11710)
-                    : c <= 11718)))))))))
-          : (c <= 11726 || (c < 42623
-            ? (c < 12540
-              ? (c < 12337
-                ? (c < 11744
-                  ? (c < 11736
-                    ? (c >= 11728 && c <= 11734)
-                    : c <= 11742)
-                  : (c <= 11775 || (c < 12321
-                    ? (c >= 12293 && c <= 12295)
-                    : c <= 12335)))
-                : (c <= 12341 || (c < 12441
-                  ? (c < 12353
-                    ? (c >= 12344 && c <= 12348)
-                    : c <= 12438)
-                  : (c <= 12442 || (c < 12449
-                    ? (c >= 12445 && c <= 12447)
-                    : c <= 12538)))))
-              : (c <= 12543 || (c < 19968
+                  : (c <= 12447 || (c >= 12449 && c <= 12538)))))))))
+          : (c <= 12543 || (c < 43011
+            ? (c < 42560
+              ? (c < 19968
                 ? (c < 12704
                   ? (c < 12593
                     ? (c >= 12549 && c <= 12591)
@@ -6910,423 +6024,354 @@ static inline bool sym_identifier_character_set_3(int32_t c) {
                   ? (c < 42240
                     ? (c >= 42192 && c <= 42237)
                     : c <= 42508)
-                  : (c <= 42539 || (c < 42612
-                    ? (c >= 42560 && c <= 42607)
-                    : c <= 42621)))))))
-            : (c <= 42737 || (c < 43232
-              ? (c < 42965
-                ? (c < 42891
-                  ? (c < 42786
-                    ? (c >= 42775 && c <= 42783)
-                    : c <= 42888)
-                  : (c <= 42954 || (c < 42963
+                  : (c <= 42527 || (c >= 42538 && c <= 42539)))))
+              : (c <= 42606 || (c < 42891
+                ? (c < 42775
+                  ? (c < 42656
+                    ? (c >= 42623 && c <= 42653)
+                    : c <= 42735)
+                  : (c <= 42783 || (c >= 42786 && c <= 42888)))
+                : (c <= 42954 || (c < 42965
+                  ? (c < 42963
                     ? (c >= 42960 && c <= 42961)
-                    : c <= 42963)))
-                : (c <= 42969 || (c < 43072
-                  ? (c < 43052
-                    ? (c >= 42994 && c <= 43047)
-                    : c <= 43052)
-                  : (c <= 43123 || (c < 43216
-                    ? (c >= 43136 && c <= 43205)
-                    : c <= 43225)))))
-              : (c <= 43255 || (c < 43471
-                ? (c < 43312
+                    : c <= 42963)
+                  : (c <= 42969 || (c >= 42994 && c <= 43009)))))))
+            : (c <= 43013 || (c < 43360
+              ? (c < 43250
+                ? (c < 43072
+                  ? (c < 43020
+                    ? (c >= 43015 && c <= 43018)
+                    : c <= 43042)
+                  : (c <= 43123 || (c >= 43138 && c <= 43187)))
+                : (c <= 43255 || (c < 43274
                   ? (c < 43261
                     ? c == 43259
-                    : c <= 43309)
-                  : (c <= 43347 || (c < 43392
-                    ? (c >= 43360 && c <= 43388)
-                    : c <= 43456)))
-                : (c <= 43481 || (c < 43584
-                  ? (c < 43520
-                    ? (c >= 43488 && c <= 43518)
-                    : c <= 43574)
-                  : (c <= 43597 || (c >= 43600 && c <= 43609)))))))))))))))
-    : (c <= 43638 || (c < 71453
-      ? (c < 67639
-        ? (c < 65345
-          ? (c < 64312
-            ? (c < 43888
-              ? (c < 43785
-                ? (c < 43744
-                  ? (c < 43739
-                    ? (c >= 43642 && c <= 43714)
-                    : c <= 43741)
-                  : (c <= 43759 || (c < 43777
-                    ? (c >= 43762 && c <= 43766)
-                    : c <= 43782)))
-                : (c <= 43790 || (c < 43816
+                    : c <= 43262)
+                  : (c <= 43301 || (c >= 43312 && c <= 43334)))))
+              : (c <= 43388 || (c < 43514
+                ? (c < 43488
+                  ? (c < 43471
+                    ? (c >= 43396 && c <= 43442)
+                    : c <= 43471)
+                  : (c <= 43492 || (c >= 43494 && c <= 43503)))
+                : (c <= 43518 || (c < 43588
+                  ? (c < 43584
+                    ? (c >= 43520 && c <= 43560)
+                    : c <= 43586)
+                  : (c <= 43595 || (c >= 43616 && c <= 43638)))))))))))))))
+    : (c <= 43642 || (c < 71168
+      ? (c < 67392
+        ? (c < 65147
+          ? (c < 63744
+            ? (c < 43785
+              ? (c < 43714
+                ? (c < 43701
+                  ? (c < 43697
+                    ? (c >= 43646 && c <= 43695)
+                    : c <= 43697)
+                  : (c <= 43702 || (c < 43712
+                    ? (c >= 43705 && c <= 43709)
+                    : c <= 43712)))
+                : (c <= 43714 || (c < 43762
+                  ? (c < 43744
+                    ? (c >= 43739 && c <= 43741)
+                    : c <= 43754)
+                  : (c <= 43764 || (c >= 43777 && c <= 43782)))))
+              : (c <= 43790 || (c < 43868
+                ? (c < 43816
                   ? (c < 43808
                     ? (c >= 43793 && c <= 43798)
                     : c <= 43814)
-                  : (c <= 43822 || (c < 43868
-                    ? (c >= 43824 && c <= 43866)
-                    : c <= 43881)))))
-              : (c <= 44010 || (c < 63744
-                ? (c < 44032
-                  ? (c < 44016
-                    ? (c >= 44012 && c <= 44013)
-                    : c <= 44025)
-                  : (c <= 55203 || (c < 55243
-                    ? (c >= 55216 && c <= 55238)
-                    : c <= 55291)))
-                : (c <= 64109 || (c < 64275
+                  : (c <= 43822 || (c >= 43824 && c <= 43866)))
+                : (c <= 43881 || (c < 55216
+                  ? (c < 44032
+                    ? (c >= 43888 && c <= 44002)
+                    : c <= 55203)
+                  : (c <= 55238 || (c >= 55243 && c <= 55291)))))))
+            : (c <= 64109 || (c < 64326
+              ? (c < 64298
+                ? (c < 64275
                   ? (c < 64256
                     ? (c >= 64112 && c <= 64217)
                     : c <= 64262)
-                  : (c <= 64279 || (c < 64298
-                    ? (c >= 64285 && c <= 64296)
-                    : c <= 64310)))))))
-            : (c <= 64316 || (c < 65075
-              ? (c < 64612
-                ? (c < 64323
-                  ? (c < 64320
-                    ? c == 64318
-                    : c <= 64321)
-                  : (c <= 64324 || (c < 64467
-                    ? (c >= 64326 && c <= 64433)
-                    : c <= 64605)))
-                : (c <= 64829 || (c < 65008
-                  ? (c < 64914
-                    ? (c >= 64848 && c <= 64911)
-                    : c <= 64967)
-                  : (c <= 65017 || (c < 65056
-                    ? (c >= 65024 && c <= 65039)
-                    : c <= 65071)))))
-              : (c <= 65076 || (c < 65147
-                ? (c < 65139
-                  ? (c < 65137
-                    ? (c >= 65101 && c <= 65103)
-                    : c <= 65137)
-                  : (c <= 65139 || (c < 65145
-                    ? c == 65143
-                    : c <= 65145)))
-                : (c <= 65147 || (c < 65296
+                  : (c <= 64279 || (c < 64287
+                    ? c == 64285
+                    : c <= 64296)))
+                : (c <= 64310 || (c < 64320
+                  ? (c < 64318
+                    ? (c >= 64312 && c <= 64316)
+                    : c <= 64318)
+                  : (c <= 64321 || (c >= 64323 && c <= 64324)))))
+              : (c <= 64433 || (c < 65008
+                ? (c < 64848
+                  ? (c < 64612
+                    ? (c >= 64467 && c <= 64605)
+                    : c <= 64829)
+                  : (c <= 64911 || (c >= 64914 && c <= 64967)))
+                : (c <= 65017 || (c < 65143
+                  ? (c < 65139
+                    ? c == 65137
+                    : c <= 65139)
+                  : (c <= 65143 || c == 65145))))))))
+          : (c <= 65147 || (c < 66304
+            ? (c < 65536
+              ? (c < 65440
+                ? (c < 65313
                   ? (c < 65151
                     ? c == 65149
                     : c <= 65276)
-                  : (c <= 65305 || (c < 65343
-                    ? (c >= 65313 && c <= 65338)
-                    : c <= 65343)))))))))
-          : (c <= 65370 || (c < 66513
-            ? (c < 65664
-              ? (c < 65536
-                ? (c < 65482
-                  ? (c < 65474
-                    ? (c >= 65382 && c <= 65470)
-                    : c <= 65479)
-                  : (c <= 65487 || (c < 65498
-                    ? (c >= 65490 && c <= 65495)
-                    : c <= 65500)))
-                : (c <= 65547 || (c < 65596
+                  : (c <= 65338 || (c < 65382
+                    ? (c >= 65345 && c <= 65370)
+                    : c <= 65437)))
+                : (c <= 65470 || (c < 65490
+                  ? (c < 65482
+                    ? (c >= 65474 && c <= 65479)
+                    : c <= 65487)
+                  : (c <= 65495 || (c >= 65498 && c <= 65500)))))
+              : (c <= 65547 || (c < 65616
+                ? (c < 65596
                   ? (c < 65576
                     ? (c >= 65549 && c <= 65574)
                     : c <= 65594)
-                  : (c <= 65597 || (c < 65616
-                    ? (c >= 65599 && c <= 65613)
-                    : c <= 65629)))))
-              : (c <= 65786 || (c < 66304
-                ? (c < 66176
-                  ? (c < 66045
-                    ? (c >= 65856 && c <= 65908)
-                    : c <= 66045)
-                  : (c <= 66204 || (c < 66272
-                    ? (c >= 66208 && c <= 66256)
-                    : c <= 66272)))
-                : (c <= 66335 || (c < 66432
+                  : (c <= 65597 || (c >= 65599 && c <= 65613)))
+                : (c <= 65629 || (c < 66176
+                  ? (c < 65856
+                    ? (c >= 65664 && c <= 65786)
+                    : c <= 65908)
+                  : (c <= 66204 || (c >= 66208 && c <= 66256)))))))
+            : (c <= 66335 || (c < 66864
+              ? (c < 66513
+                ? (c < 66432
                   ? (c < 66384
                     ? (c >= 66349 && c <= 66378)
-                    : c <= 66426)
+                    : c <= 66421)
                   : (c <= 66461 || (c < 66504
                     ? (c >= 66464 && c <= 66499)
-                    : c <= 66511)))))))
-            : (c <= 66517 || (c < 66979
-              ? (c < 66864
-                ? (c < 66736
-                  ? (c < 66720
+                    : c <= 66511)))
+                : (c <= 66517 || (c < 66776
+                  ? (c < 66736
                     ? (c >= 66560 && c <= 66717)
-                    : c <= 66729)
-                  : (c <= 66771 || (c < 66816
-                    ? (c >= 66776 && c <= 66811)
-                    : c <= 66855)))
-                : (c <= 66915 || (c < 66956
+                    : c <= 66771)
+                  : (c <= 66811 || (c >= 66816 && c <= 66855)))))
+              : (c <= 66915 || (c < 66967
+                ? (c < 66956
                   ? (c < 66940
                     ? (c >= 66928 && c <= 66938)
                     : c <= 66954)
-                  : (c <= 66962 || (c < 66967
-                    ? (c >= 66964 && c <= 66965)
-                    : c <= 66977)))))
-              : (c <= 66993 || (c < 67456
-                ? (c < 67072
-                  ? (c < 67003
-                    ? (c >= 66995 && c <= 67001)
-                    : c <= 67004)
-                  : (c <= 67382 || (c < 67424
-                    ? (c >= 67392 && c <= 67413)
-                    : c <= 67431)))
-                : (c <= 67461 || (c < 67584
-                  ? (c < 67506
-                    ? (c >= 67463 && c <= 67504)
-                    : c <= 67514)
-                  : (c <= 67589 || (c < 67594
-                    ? c == 67592
-                    : c <= 67637)))))))))))
-        : (c <= 67640 || (c < 69956
-          ? (c < 68448
-            ? (c < 68101
-              ? (c < 67828
-                ? (c < 67680
-                  ? (c < 67647
-                    ? c == 67644
-                    : c <= 67669)
-                  : (c <= 67702 || (c < 67808
+                  : (c <= 66962 || (c >= 66964 && c <= 66965)))
+                : (c <= 66977 || (c < 67003
+                  ? (c < 66995
+                    ? (c >= 66979 && c <= 66993)
+                    : c <= 67001)
+                  : (c <= 67004 || (c >= 67072 && c <= 67382)))))))))))
+        : (c <= 67413 || (c < 69600
+          ? (c < 68117
+            ? (c < 67680
+              ? (c < 67592
+                ? (c < 67463
+                  ? (c < 67456
+                    ? (c >= 67424 && c <= 67431)
+                    : c <= 67461)
+                  : (c <= 67504 || (c < 67584
+                    ? (c >= 67506 && c <= 67514)
+                    : c <= 67589)))
+                : (c <= 67592 || (c < 67644
+                  ? (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)
+                  : (c <= 67644 || (c >= 67647 && c <= 67669)))))
+              : (c <= 67702 || (c < 67872
+                ? (c < 67828
+                  ? (c < 67808
                     ? (c >= 67712 && c <= 67742)
-                    : c <= 67826)))
-                : (c <= 67829 || (c < 67968
-                  ? (c < 67872
-                    ? (c >= 67840 && c <= 67861)
-                    : c <= 67897)
-                  : (c <= 68023 || (c < 68096
-                    ? (c >= 68030 && c <= 68031)
-                    : c <= 68099)))))
-              : (c <= 68102 || (c < 68192
-                ? (c < 68121
-                  ? (c < 68117
-                    ? (c >= 68108 && c <= 68115)
-                    : c <= 68119)
-                  : (c <= 68149 || (c < 68159
-                    ? (c >= 68152 && c <= 68154)
-                    : c <= 68159)))
-                : (c <= 68220 || (c < 68297
-                  ? (c < 68288
-                    ? (c >= 68224 && c <= 68252)
-                    : c <= 68295)
-                  : (c <= 68326 || (c < 68416
-                    ? (c >= 68352 && c <= 68405)
-                    : c <= 68437)))))))
-            : (c <= 68466 || (c < 69424
-              ? (c < 68912
-                ? (c < 68736
-                  ? (c < 68608
-                    ? (c >= 68480 && c <= 68497)
-                    : c <= 68680)
-                  : (c <= 68786 || (c < 68864
+                    : c <= 67826)
+                  : (c <= 67829 || (c >= 67840 && c <= 67861)))
+                : (c <= 67897 || (c < 68096
+                  ? (c < 68030
+                    ? (c >= 67968 && c <= 68023)
+                    : c <= 68031)
+                  : (c <= 68096 || (c >= 68112 && c <= 68115)))))))
+            : (c <= 68119 || (c < 68736
+              ? (c < 68352
+                ? (c < 68224
+                  ? (c < 68192
+                    ? (c >= 68121 && c <= 68149)
+                    : c <= 68220)
+                  : (c <= 68252 || (c < 68297
+                    ? (c >= 68288 && c <= 68295)
+                    : c <= 68324)))
+                : (c <= 68405 || (c < 68480
+                  ? (c < 68448
+                    ? (c >= 68416 && c <= 68437)
+                    : c <= 68466)
+                  : (c <= 68497 || (c >= 68608 && c <= 68680)))))
+              : (c <= 68786 || (c < 69376
+                ? (c < 69248
+                  ? (c < 68864
                     ? (c >= 68800 && c <= 68850)
-                    : c <= 68903)))
-                : (c <= 68921 || (c < 69296
-                  ? (c < 69291
-                    ? (c >= 69248 && c <= 69289)
-                    : c <= 69292)
-                  : (c <= 69297 || (c < 69415
-                    ? (c >= 69376 && c <= 69404)
-                    : c <= 69415)))))
-              : (c <= 69456 || (c < 69759
-                ? (c < 69600
-                  ? (c < 69552
-                    ? (c >= 69488 && c <= 69509)
-                    : c <= 69572)
-                  : (c <= 69622 || (c < 69734
-                    ? (c >= 69632 && c <= 69702)
-                    : c <= 69749)))
-                : (c <= 69818 || (c < 69872
-                  ? (c < 69840
-                    ? c == 69826
-                    : c <= 69864)
-                  : (c <= 69881 || (c < 69942
-                    ? (c >= 69888 && c <= 69940)
-                    : c <= 69951)))))))))
-          : (c <= 69959 || (c < 70459
-            ? (c < 70282
-              ? (c < 70108
-                ? (c < 70016
-                  ? (c < 70006
-                    ? (c >= 69968 && c <= 70003)
-                    : c <= 70006)
-                  : (c <= 70084 || (c < 70094
-                    ? (c >= 70089 && c <= 70092)
-                    : c <= 70106)))
-                : (c <= 70108 || (c < 70206
-                  ? (c < 70163
-                    ? (c >= 70144 && c <= 70161)
-                    : c <= 70199)
-                  : (c <= 70206 || (c < 70280
-                    ? (c >= 70272 && c <= 70278)
-                    : c <= 70280)))))
-              : (c <= 70285 || (c < 70405
-                ? (c < 70320
-                  ? (c < 70303
-                    ? (c >= 70287 && c <= 70301)
-                    : c <= 70312)
-                  : (c <= 70378 || (c < 70400
-                    ? (c >= 70384 && c <= 70393)
-                    : c <= 70403)))
-                : (c <= 70412 || (c < 70442
-                  ? (c < 70419
-                    ? (c >= 70415 && c <= 70416)
-                    : c <= 70440)
-                  : (c <= 70448 || (c < 70453
-                    ? (c >= 70450 && c <= 70451)
-                    : c <= 70457)))))))
-            : (c <= 70468 || (c < 70855
-              ? (c < 70502
-                ? (c < 70480
-                  ? (c < 70475
-                    ? (c >= 70471 && c <= 70472)
-                    : c <= 70477)
-                  : (c <= 70480 || (c < 70493
-                    ? c == 70487
-                    : c <= 70499)))
-                : (c <= 70508 || (c < 70736
+                    : c <= 68899)
+                  : (c <= 69289 || (c >= 69296 && c <= 69297)))
+                : (c <= 69404 || (c < 69488
+                  ? (c < 69424
+                    ? c == 69415
+                    : c <= 69445)
+                  : (c <= 69505 || (c >= 69552 && c <= 69572)))))))))
+          : (c <= 69622 || (c < 70287
+            ? (c < 70019
+              ? (c < 69891
+                ? (c < 69749
+                  ? (c < 69745
+                    ? (c >= 69635 && c <= 69687)
+                    : c <= 69746)
+                  : (c <= 69749 || (c < 69840
+                    ? (c >= 69763 && c <= 69807)
+                    : c <= 69864)))
+                : (c <= 69926 || (c < 69968
+                  ? (c < 69959
+                    ? c == 69956
+                    : c <= 69959)
+                  : (c <= 70002 || c == 70006))))
+              : (c <= 70066 || (c < 70163
+                ? (c < 70108
+                  ? (c < 70106
+                    ? (c >= 70081 && c <= 70084)
+                    : c <= 70106)
+                  : (c <= 70108 || (c >= 70144 && c <= 70161)))
+                : (c <= 70187 || (c < 70280
+                  ? (c < 70272
+                    ? (c >= 70207 && c <= 70208)
+                    : c <= 70278)
+                  : (c <= 70280 || (c >= 70282 && c <= 70285)))))))
+            : (c <= 70301 || (c < 70480
+              ? (c < 70419
+                ? (c < 70405
+                  ? (c < 70320
+                    ? (c >= 70303 && c <= 70312)
+                    : c <= 70366)
+                  : (c <= 70412 || (c >= 70415 && c <= 70416)))
+                : (c <= 70440 || (c < 70453
+                  ? (c < 70450
+                    ? (c >= 70442 && c <= 70448)
+                    : c <= 70451)
+                  : (c <= 70457 || c == 70461))))
+              : (c <= 70480 || (c < 70784
+                ? (c < 70727
                   ? (c < 70656
-                    ? (c >= 70512 && c <= 70516)
-                    : c <= 70730)
-                  : (c <= 70745 || (c < 70784
-                    ? (c >= 70750 && c <= 70753)
-                    : c <= 70853)))))
-              : (c <= 70855 || (c < 71236
-                ? (c < 71096
-                  ? (c < 71040
-                    ? (c >= 70864 && c <= 70873)
-                    : c <= 71093)
-                  : (c <= 71104 || (c < 71168
-                    ? (c >= 71128 && c <= 71133)
-                    : c <= 71232)))
-                : (c <= 71236 || (c < 71360
+                    ? (c >= 70493 && c <= 70497)
+                    : c <= 70708)
+                  : (c <= 70730 || (c >= 70751 && c <= 70753)))
+                : (c <= 70831 || (c < 71040
+                  ? (c < 70855
+                    ? (c >= 70852 && c <= 70853)
+                    : c <= 70855)
+                  : (c <= 71086 || (c >= 71128 && c <= 71131)))))))))))))
+      : (c <= 71215 || (c < 119973
+        ? (c < 73648
+          ? (c < 72250
+            ? (c < 71957
+              ? (c < 71680
+                ? (c < 71352
                   ? (c < 71296
-                    ? (c >= 71248 && c <= 71257)
-                    : c <= 71352)
-                  : (c <= 71369 || (c >= 71424 && c <= 71450)))))))))))))
-      : (c <= 71467 || (c < 119973
-        ? (c < 77824
-          ? (c < 72760
-            ? (c < 72016
-              ? (c < 71945
-                ? (c < 71680
-                  ? (c < 71488
-                    ? (c >= 71472 && c <= 71481)
-                    : c <= 71494)
-                  : (c <= 71738 || (c < 71935
-                    ? (c >= 71840 && c <= 71913)
-                    : c <= 71942)))
-                : (c <= 71945 || (c < 71960
-                  ? (c < 71957
-                    ? (c >= 71948 && c <= 71955)
-                    : c <= 71958)
-                  : (c <= 71989 || (c < 71995
-                    ? (c >= 71991 && c <= 71992)
-                    : c <= 72003)))))
-              : (c <= 72025 || (c < 72263
-                ? (c < 72154
-                  ? (c < 72106
-                    ? (c >= 72096 && c <= 72103)
-                    : c <= 72151)
-                  : (c <= 72161 || (c < 72192
-                    ? (c >= 72163 && c <= 72164)
-                    : c <= 72254)))
-                : (c <= 72263 || (c < 72368
-                  ? (c < 72349
-                    ? (c >= 72272 && c <= 72345)
-                    : c <= 72349)
-                  : (c <= 72440 || (c < 72714
-                    ? (c >= 72704 && c <= 72712)
-                    : c <= 72758)))))))
-            : (c <= 72768 || (c < 73056
-              ? (c < 72968
-                ? (c < 72850
+                    ? c == 71236
+                    : c <= 71338)
+                  : (c <= 71352 || (c < 71488
+                    ? (c >= 71424 && c <= 71450)
+                    : c <= 71494)))
+                : (c <= 71723 || (c < 71945
+                  ? (c < 71935
+                    ? (c >= 71840 && c <= 71903)
+                    : c <= 71942)
+                  : (c <= 71945 || (c >= 71948 && c <= 71955)))))
+              : (c <= 71958 || (c < 72106
+                ? (c < 72001
+                  ? (c < 71999
+                    ? (c >= 71960 && c <= 71983)
+                    : c <= 71999)
+                  : (c <= 72001 || (c >= 72096 && c <= 72103)))
+                : (c <= 72144 || (c < 72192
+                  ? (c < 72163
+                    ? c == 72161
+                    : c <= 72163)
+                  : (c <= 72192 || (c >= 72203 && c <= 72242)))))))
+            : (c <= 72250 || (c < 72971
+              ? (c < 72714
+                ? (c < 72349
+                  ? (c < 72284
+                    ? c == 72272
+                    : c <= 72329)
+                  : (c <= 72349 || (c < 72704
+                    ? (c >= 72368 && c <= 72440)
+                    : c <= 72712)))
+                : (c <= 72750 || (c < 72960
                   ? (c < 72818
-                    ? (c >= 72784 && c <= 72793)
+                    ? c == 72768
                     : c <= 72847)
-                  : (c <= 72871 || (c < 72960
-                    ? (c >= 72873 && c <= 72886)
-                    : c <= 72966)))
-                : (c <= 72969 || (c < 73020
-                  ? (c < 73018
-                    ? (c >= 72971 && c <= 73014)
-                    : c <= 73018)
-                  : (c <= 73021 || (c < 73040
-                    ? (c >= 73023 && c <= 73031)
-                    : c <= 73049)))))
-              : (c <= 73061 || (c < 73440
-                ? (c < 73104
-                  ? (c < 73066
-                    ? (c >= 73063 && c <= 73064)
-                    : c <= 73102)
-                  : (c <= 73105 || (c < 73120
-                    ? (c >= 73107 && c <= 73112)
-                    : c <= 73129)))
-                : (c <= 73462 || (c < 74752
-                  ? (c < 73728
-                    ? c == 73648
-                    : c <= 74649)
-                  : (c <= 74862 || (c < 77712
-                    ? (c >= 74880 && c <= 75075)
-                    : c <= 77808)))))))))
-          : (c <= 78894 || (c < 110576
-            ? (c < 93027
-              ? (c < 92864
-                ? (c < 92736
+                  : (c <= 72966 || (c >= 72968 && c <= 72969)))))
+              : (c <= 73008 || (c < 73112
+                ? (c < 73063
+                  ? (c < 73056
+                    ? c == 73030
+                    : c <= 73061)
+                  : (c <= 73064 || (c >= 73066 && c <= 73097)))
+                : (c <= 73112 || (c < 73476
+                  ? (c < 73474
+                    ? (c >= 73440 && c <= 73458)
+                    : c <= 73474)
+                  : (c <= 73488 || (c >= 73490 && c <= 73523)))))))))
+          : (c <= 73648 || (c < 94179
+            ? (c < 92880
+              ? (c < 78913
+                ? (c < 74880
+                  ? (c < 74752
+                    ? (c >= 73728 && c <= 74649)
+                    : c <= 74862)
+                  : (c <= 75075 || (c < 77824
+                    ? (c >= 77712 && c <= 77808)
+                    : c <= 78895)))
+                : (c <= 78918 || (c < 92736
                   ? (c < 92160
                     ? (c >= 82944 && c <= 83526)
                     : c <= 92728)
-                  : (c <= 92766 || (c < 92784
-                    ? (c >= 92768 && c <= 92777)
-                    : c <= 92862)))
-                : (c <= 92873 || (c < 92928
-                  ? (c < 92912
-                    ? (c >= 92880 && c <= 92909)
-                    : c <= 92916)
-                  : (c <= 92982 || (c < 93008
-                    ? (c >= 92992 && c <= 92995)
-                    : c <= 93017)))))
-              : (c <= 93047 || (c < 94176
-                ? (c < 93952
-                  ? (c < 93760
-                    ? (c >= 93053 && c <= 93071)
-                    : c <= 93823)
-                  : (c <= 94026 || (c < 94095
-                    ? (c >= 94031 && c <= 94087)
-                    : c <= 94111)))
-                : (c <= 94177 || (c < 94208
-                  ? (c < 94192
-                    ? (c >= 94179 && c <= 94180)
-                    : c <= 94193)
-                  : (c <= 100343 || (c < 101632
-                    ? (c >= 100352 && c <= 101589)
-                    : c <= 101640)))))))
-            : (c <= 110579 || (c < 118528
-              ? (c < 110960
-                ? (c < 110592
-                  ? (c < 110589
-                    ? (c >= 110581 && c <= 110587)
-                    : c <= 110590)
-                  : (c <= 110882 || (c < 110948
-                    ? (c >= 110928 && c <= 110930)
-                    : c <= 110951)))
-                : (c <= 111355 || (c < 113792
-                  ? (c < 113776
-                    ? (c >= 113664 && c <= 113770)
-                    : c <= 113788)
-                  : (c <= 113800 || (c < 113821
-                    ? (c >= 113808 && c <= 113817)
-                    : c <= 113822)))))
-              : (c <= 118573 || (c < 119210
-                ? (c < 119149
-                  ? (c < 119141
-                    ? (c >= 118576 && c <= 118598)
-                    : c <= 119145)
-                  : (c <= 119154 || (c < 119173
-                    ? (c >= 119163 && c <= 119170)
-                    : c <= 119179)))
-                : (c <= 119213 || (c < 119894
-                  ? (c < 119808
-                    ? (c >= 119362 && c <= 119364)
-                    : c <= 119892)
-                  : (c <= 119964 || (c < 119970
-                    ? (c >= 119966 && c <= 119967)
-                    : c <= 119970)))))))))))
-        : (c <= 119974 || (c < 124912
-          ? (c < 120746
-            ? (c < 120134
+                  : (c <= 92766 || (c >= 92784 && c <= 92862)))))
+              : (c <= 92909 || (c < 93760
+                ? (c < 93027
+                  ? (c < 92992
+                    ? (c >= 92928 && c <= 92975)
+                    : c <= 92995)
+                  : (c <= 93047 || (c >= 93053 && c <= 93071)))
+                : (c <= 93823 || (c < 94099
+                  ? (c < 94032
+                    ? (c >= 93952 && c <= 94026)
+                    : c <= 94032)
+                  : (c <= 94111 || (c >= 94176 && c <= 94177)))))))
+            : (c <= 94179 || (c < 110948
+              ? (c < 110589
+                ? (c < 101632
+                  ? (c < 100352
+                    ? (c >= 94208 && c <= 100343)
+                    : c <= 101589)
+                  : (c <= 101640 || (c < 110581
+                    ? (c >= 110576 && c <= 110579)
+                    : c <= 110587)))
+                : (c <= 110590 || (c < 110928
+                  ? (c < 110898
+                    ? (c >= 110592 && c <= 110882)
+                    : c <= 110898)
+                  : (c <= 110930 || c == 110933))))
+              : (c <= 110951 || (c < 113808
+                ? (c < 113776
+                  ? (c < 113664
+                    ? (c >= 110960 && c <= 111355)
+                    : c <= 113770)
+                  : (c <= 113788 || (c >= 113792 && c <= 113800)))
+                : (c <= 113817 || (c < 119966
+                  ? (c < 119894
+                    ? (c >= 119808 && c <= 119892)
+                    : c <= 119964)
+                  : (c <= 119967 || c == 119970))))))))))
+        : (c <= 119974 || (c < 126464
+          ? (c < 120656
+            ? (c < 120128
               ? (c < 120071
                 ? (c < 119995
                   ? (c < 119982
@@ -7339,52 +6384,1052 @@ static inline bool sym_identifier_character_set_3(int32_t c) {
                   ? (c < 120086
                     ? (c >= 120077 && c <= 120084)
                     : c <= 120092)
-                  : (c <= 120121 || (c < 120128
-                    ? (c >= 120123 && c <= 120126)
-                    : c <= 120132)))))
-              : (c <= 120134 || (c < 120572
-                ? (c < 120488
-                  ? (c < 120146
-                    ? (c >= 120138 && c <= 120144)
-                    : c <= 120485)
-                  : (c <= 120512 || (c < 120540
-                    ? (c >= 120514 && c <= 120538)
-                    : c <= 120570)))
-                : (c <= 120596 || (c < 120656
-                  ? (c < 120630
-                    ? (c >= 120598 && c <= 120628)
-                    : c <= 120654)
-                  : (c <= 120686 || (c < 120714
+                  : (c <= 120121 || (c >= 120123 && c <= 120126)))))
+              : (c <= 120132 || (c < 120514
+                ? (c < 120146
+                  ? (c < 120138
+                    ? c == 120134
+                    : c <= 120144)
+                  : (c <= 120485 || (c >= 120488 && c <= 120512)))
+                : (c <= 120538 || (c < 120598
+                  ? (c < 120572
+                    ? (c >= 120540 && c <= 120570)
+                    : c <= 120596)
+                  : (c <= 120628 || (c >= 120630 && c <= 120654)))))))
+            : (c <= 120686 || (c < 123536
+              ? (c < 122661
+                ? (c < 120746
+                  ? (c < 120714
                     ? (c >= 120688 && c <= 120712)
-                    : c <= 120744)))))))
-            : (c <= 120770 || (c < 122907
-              ? (c < 121476
-                ? (c < 121344
-                  ? (c < 120782
+                    : c <= 120744)
+                  : (c <= 120770 || (c < 122624
                     ? (c >= 120772 && c <= 120779)
-                    : c <= 120831)
-                  : (c <= 121398 || (c < 121461
-                    ? (c >= 121403 && c <= 121452)
-                    : c <= 121461)))
-                : (c <= 121476 || (c < 122624
-                  ? (c < 121505
-                    ? (c >= 121499 && c <= 121503)
-                    : c <= 121519)
-                  : (c <= 122654 || (c < 122888
+                    : c <= 122654)))
+                : (c <= 122666 || (c < 123191
+                  ? (c < 123136
+                    ? (c >= 122928 && c <= 122989)
+                    : c <= 123180)
+                  : (c <= 123197 || c == 123214))))
+              : (c <= 123565 || (c < 124909
+                ? (c < 124896
+                  ? (c < 124112
+                    ? (c >= 123584 && c <= 123627)
+                    : c <= 124139)
+                  : (c <= 124902 || (c >= 124904 && c <= 124907)))
+                : (c <= 124910 || (c < 125184
+                  ? (c < 124928
+                    ? (c >= 124912 && c <= 124926)
+                    : c <= 125124)
+                  : (c <= 125251 || c == 125259))))))))
+          : (c <= 126467 || (c < 126561
+            ? (c < 126537
+              ? (c < 126516
+                ? (c < 126500
+                  ? (c < 126497
+                    ? (c >= 126469 && c <= 126495)
+                    : c <= 126498)
+                  : (c <= 126500 || (c < 126505
+                    ? c == 126503
+                    : c <= 126514)))
+                : (c <= 126519 || (c < 126530
+                  ? (c < 126523
+                    ? c == 126521
+                    : c <= 126523)
+                  : (c <= 126530 || c == 126535))))
+              : (c <= 126537 || (c < 126551
+                ? (c < 126545
+                  ? (c < 126541
+                    ? c == 126539
+                    : c <= 126543)
+                  : (c <= 126546 || c == 126548))
+                : (c <= 126551 || (c < 126557
+                  ? (c < 126555
+                    ? c == 126553
+                    : c <= 126555)
+                  : (c <= 126557 || c == 126559))))))
+            : (c <= 126562 || (c < 126629
+              ? (c < 126585
+                ? (c < 126572
+                  ? (c < 126567
+                    ? c == 126564
+                    : c <= 126570)
+                  : (c <= 126578 || (c >= 126580 && c <= 126583)))
+                : (c <= 126588 || (c < 126603
+                  ? (c < 126592
+                    ? c == 126590
+                    : c <= 126601)
+                  : (c <= 126619 || (c >= 126625 && c <= 126627)))))
+              : (c <= 126633 || (c < 178208
+                ? (c < 173824
+                  ? (c < 131072
+                    ? (c >= 126635 && c <= 126651)
+                    : c <= 173791)
+                  : (c <= 177977 || (c >= 177984 && c <= 178205)))
+                : (c <= 183969 || (c < 196608
+                  ? (c < 194560
+                    ? (c >= 183984 && c <= 191456)
+                    : c <= 195101)
+                  : (c <= 201546 || (c >= 201552 && c <= 205743)))))))))))))))));
+}
+
+static inline bool sym_identifier_character_set_3(int32_t c) {
+  return (c < 43785
+    ? (c < 3804
+      ? (c < 2759
+        ? (c < 2048
+          ? (c < 1155
+            ? (c < 736
+              ? (c < 183
+                ? (c < 'a'
+                  ? (c < 'A'
+                    ? (c >= '0' && c <= '9')
+                    : (c <= 'Z' || c == '_'))
+                  : (c <= 'z' || (c < 181
+                    ? c == 170
+                    : c <= 181)))
+                : (c <= 183 || (c < 216
+                  ? (c < 192
+                    ? c == 186
+                    : c <= 214)
+                  : (c <= 246 || (c < 710
+                    ? (c >= 248 && c <= 705)
+                    : c <= 721)))))
+              : (c <= 740 || (c < 895
+                ? (c < 768
+                  ? (c < 750
+                    ? c == 748
+                    : c <= 750)
+                  : (c <= 884 || (c < 891
+                    ? (c >= 886 && c <= 887)
+                    : c <= 893)))
+                : (c <= 895 || (c < 910
+                  ? (c < 908
+                    ? (c >= 902 && c <= 906)
+                    : c <= 908)
+                  : (c <= 929 || (c < 1015
+                    ? (c >= 931 && c <= 1013)
+                    : c <= 1153)))))))
+            : (c <= 1159 || (c < 1552
+              ? (c < 1471
+                ? (c < 1369
+                  ? (c < 1329
+                    ? (c >= 1162 && c <= 1327)
+                    : c <= 1366)
+                  : (c <= 1369 || (c < 1425
+                    ? (c >= 1376 && c <= 1416)
+                    : c <= 1469)))
+                : (c <= 1471 || (c < 1479
+                  ? (c < 1476
+                    ? (c >= 1473 && c <= 1474)
+                    : c <= 1477)
+                  : (c <= 1479 || (c < 1519
+                    ? (c >= 1488 && c <= 1514)
+                    : c <= 1522)))))
+              : (c <= 1562 || (c < 1791
+                ? (c < 1749
+                  ? (c < 1646
+                    ? (c >= 1568 && c <= 1641)
+                    : c <= 1747)
+                  : (c <= 1756 || (c < 1770
+                    ? (c >= 1759 && c <= 1768)
+                    : c <= 1788)))
+                : (c <= 1791 || (c < 1984
+                  ? (c < 1869
+                    ? (c >= 1808 && c <= 1866)
+                    : c <= 1969)
+                  : (c <= 2037 || (c < 2045
+                    ? c == 2042
+                    : c <= 2045)))))))))
+          : (c <= 2093 || (c < 2561
+            ? (c < 2474
+              ? (c < 2275
+                ? (c < 2160
+                  ? (c < 2144
+                    ? (c >= 2112 && c <= 2139)
+                    : c <= 2154)
+                  : (c <= 2183 || (c < 2200
+                    ? (c >= 2185 && c <= 2190)
+                    : c <= 2273)))
+                : (c <= 2403 || (c < 2437
+                  ? (c < 2417
+                    ? (c >= 2406 && c <= 2415)
+                    : c <= 2435)
+                  : (c <= 2444 || (c < 2451
+                    ? (c >= 2447 && c <= 2448)
+                    : c <= 2472)))))
+              : (c <= 2480 || (c < 2519
+                ? (c < 2492
+                  ? (c < 2486
+                    ? c == 2482
+                    : c <= 2489)
+                  : (c <= 2500 || (c < 2507
+                    ? (c >= 2503 && c <= 2504)
+                    : c <= 2510)))
+                : (c <= 2519 || (c < 2534
+                  ? (c < 2527
+                    ? (c >= 2524 && c <= 2525)
+                    : c <= 2531)
+                  : (c <= 2545 || (c < 2558
+                    ? c == 2556
+                    : c <= 2558)))))))
+            : (c <= 2563 || (c < 2641
+              ? (c < 2613
+                ? (c < 2579
+                  ? (c < 2575
+                    ? (c >= 2565 && c <= 2570)
+                    : c <= 2576)
+                  : (c <= 2600 || (c < 2610
+                    ? (c >= 2602 && c <= 2608)
+                    : c <= 2611)))
+                : (c <= 2614 || (c < 2622
+                  ? (c < 2620
+                    ? (c >= 2616 && c <= 2617)
+                    : c <= 2620)
+                  : (c <= 2626 || (c < 2635
+                    ? (c >= 2631 && c <= 2632)
+                    : c <= 2637)))))
+              : (c <= 2641 || (c < 2703
+                ? (c < 2662
+                  ? (c < 2654
+                    ? (c >= 2649 && c <= 2652)
+                    : c <= 2654)
+                  : (c <= 2677 || (c < 2693
+                    ? (c >= 2689 && c <= 2691)
+                    : c <= 2701)))
+                : (c <= 2705 || (c < 2738
+                  ? (c < 2730
+                    ? (c >= 2707 && c <= 2728)
+                    : c <= 2736)
+                  : (c <= 2739 || (c < 2748
+                    ? (c >= 2741 && c <= 2745)
+                    : c <= 2757)))))))))))
+        : (c <= 2761 || (c < 3200
+          ? (c < 2969
+            ? (c < 2876
+              ? (c < 2821
+                ? (c < 2790
+                  ? (c < 2768
+                    ? (c >= 2763 && c <= 2765)
+                    : (c <= 2768 || (c >= 2784 && c <= 2787)))
+                  : (c <= 2799 || (c < 2817
+                    ? (c >= 2809 && c <= 2815)
+                    : c <= 2819)))
+                : (c <= 2828 || (c < 2858
+                  ? (c < 2835
+                    ? (c >= 2831 && c <= 2832)
+                    : c <= 2856)
+                  : (c <= 2864 || (c < 2869
+                    ? (c >= 2866 && c <= 2867)
+                    : c <= 2873)))))
+              : (c <= 2884 || (c < 2918
+                ? (c < 2901
+                  ? (c < 2891
+                    ? (c >= 2887 && c <= 2888)
+                    : c <= 2893)
+                  : (c <= 2903 || (c < 2911
+                    ? (c >= 2908 && c <= 2909)
+                    : c <= 2915)))
+                : (c <= 2927 || (c < 2949
+                  ? (c < 2946
+                    ? c == 2929
+                    : c <= 2947)
+                  : (c <= 2954 || (c < 2962
+                    ? (c >= 2958 && c <= 2960)
+                    : c <= 2965)))))))
+            : (c <= 2970 || (c < 3072
+              ? (c < 3006
+                ? (c < 2979
+                  ? (c < 2974
+                    ? c == 2972
+                    : c <= 2975)
+                  : (c <= 2980 || (c < 2990
+                    ? (c >= 2984 && c <= 2986)
+                    : c <= 3001)))
+                : (c <= 3010 || (c < 3024
+                  ? (c < 3018
+                    ? (c >= 3014 && c <= 3016)
+                    : c <= 3021)
+                  : (c <= 3024 || (c < 3046
+                    ? c == 3031
+                    : c <= 3055)))))
+              : (c <= 3084 || (c < 3146
+                ? (c < 3114
+                  ? (c < 3090
+                    ? (c >= 3086 && c <= 3088)
+                    : c <= 3112)
+                  : (c <= 3129 || (c < 3142
+                    ? (c >= 3132 && c <= 3140)
+                    : c <= 3144)))
+                : (c <= 3149 || (c < 3165
+                  ? (c < 3160
+                    ? (c >= 3157 && c <= 3158)
+                    : c <= 3162)
+                  : (c <= 3165 || (c < 3174
+                    ? (c >= 3168 && c <= 3171)
+                    : c <= 3183)))))))))
+          : (c <= 3203 || (c < 3461
+            ? (c < 3302
+              ? (c < 3260
+                ? (c < 3218
+                  ? (c < 3214
+                    ? (c >= 3205 && c <= 3212)
+                    : c <= 3216)
+                  : (c <= 3240 || (c < 3253
+                    ? (c >= 3242 && c <= 3251)
+                    : c <= 3257)))
+                : (c <= 3268 || (c < 3285
+                  ? (c < 3274
+                    ? (c >= 3270 && c <= 3272)
+                    : c <= 3277)
+                  : (c <= 3286 || (c < 3296
+                    ? (c >= 3293 && c <= 3294)
+                    : c <= 3299)))))
+              : (c <= 3311 || (c < 3402
+                ? (c < 3342
+                  ? (c < 3328
+                    ? (c >= 3313 && c <= 3315)
+                    : c <= 3340)
+                  : (c <= 3344 || (c < 3398
+                    ? (c >= 3346 && c <= 3396)
+                    : c <= 3400)))
+                : (c <= 3406 || (c < 3430
+                  ? (c < 3423
+                    ? (c >= 3412 && c <= 3415)
+                    : c <= 3427)
+                  : (c <= 3439 || (c < 3457
+                    ? (c >= 3450 && c <= 3455)
+                    : c <= 3459)))))))
+            : (c <= 3478 || (c < 3648
+              ? (c < 3535
+                ? (c < 3517
+                  ? (c < 3507
+                    ? (c >= 3482 && c <= 3505)
+                    : c <= 3515)
+                  : (c <= 3517 || (c < 3530
+                    ? (c >= 3520 && c <= 3526)
+                    : c <= 3530)))
+                : (c <= 3540 || (c < 3558
+                  ? (c < 3544
+                    ? c == 3542
+                    : c <= 3551)
+                  : (c <= 3567 || (c < 3585
+                    ? (c >= 3570 && c <= 3571)
+                    : c <= 3642)))))
+              : (c <= 3662 || (c < 3749
+                ? (c < 3716
+                  ? (c < 3713
+                    ? (c >= 3664 && c <= 3673)
+                    : c <= 3714)
+                  : (c <= 3716 || (c < 3724
+                    ? (c >= 3718 && c <= 3722)
+                    : c <= 3747)))
+                : (c <= 3749 || (c < 3782
+                  ? (c < 3776
+                    ? (c >= 3751 && c <= 3773)
+                    : c <= 3780)
+                  : (c <= 3782 || (c < 3792
+                    ? (c >= 3784 && c <= 3790)
+                    : c <= 3801)))))))))))))
+      : (c <= 3807 || (c < 8064
+        ? (c < 5998
+          ? (c < 4746
+            ? (c < 4096
+              ? (c < 3902
+                ? (c < 3893
+                  ? (c < 3864
+                    ? c == 3840
+                    : (c <= 3865 || (c >= 3872 && c <= 3881)))
+                  : (c <= 3893 || (c < 3897
+                    ? c == 3895
+                    : c <= 3897)))
+                : (c <= 3911 || (c < 3974
+                  ? (c < 3953
+                    ? (c >= 3913 && c <= 3948)
+                    : c <= 3972)
+                  : (c <= 3991 || (c < 4038
+                    ? (c >= 3993 && c <= 4028)
+                    : c <= 4038)))))
+              : (c <= 4169 || (c < 4348
+                ? (c < 4295
+                  ? (c < 4256
+                    ? (c >= 4176 && c <= 4253)
+                    : c <= 4293)
+                  : (c <= 4295 || (c < 4304
+                    ? c == 4301
+                    : c <= 4346)))
+                : (c <= 4680 || (c < 4696
+                  ? (c < 4688
+                    ? (c >= 4682 && c <= 4685)
+                    : c <= 4694)
+                  : (c <= 4696 || (c < 4704
+                    ? (c >= 4698 && c <= 4701)
+                    : c <= 4744)))))))
+            : (c <= 4749 || (c < 4992
+              ? (c < 4808
+                ? (c < 4792
+                  ? (c < 4786
+                    ? (c >= 4752 && c <= 4784)
+                    : c <= 4789)
+                  : (c <= 4798 || (c < 4802
+                    ? c == 4800
+                    : c <= 4805)))
+                : (c <= 4822 || (c < 4888
+                  ? (c < 4882
+                    ? (c >= 4824 && c <= 4880)
+                    : c <= 4885)
+                  : (c <= 4954 || (c < 4969
+                    ? (c >= 4957 && c <= 4959)
+                    : c <= 4977)))))
+              : (c <= 5007 || (c < 5792
+                ? (c < 5121
+                  ? (c < 5112
+                    ? (c >= 5024 && c <= 5109)
+                    : c <= 5117)
+                  : (c <= 5740 || (c < 5761
+                    ? (c >= 5743 && c <= 5759)
+                    : c <= 5786)))
+                : (c <= 5866 || (c < 5919
+                  ? (c < 5888
+                    ? (c >= 5870 && c <= 5880)
+                    : c <= 5909)
+                  : (c <= 5940 || (c < 5984
+                    ? (c >= 5952 && c <= 5971)
+                    : c <= 5996)))))))))
+          : (c <= 6000 || (c < 6823
+            ? (c < 6432
+              ? (c < 6155
+                ? (c < 6103
+                  ? (c < 6016
+                    ? (c >= 6002 && c <= 6003)
+                    : c <= 6099)
+                  : (c <= 6103 || (c < 6112
+                    ? (c >= 6108 && c <= 6109)
+                    : c <= 6121)))
+                : (c <= 6157 || (c < 6272
+                  ? (c < 6176
+                    ? (c >= 6159 && c <= 6169)
+                    : c <= 6264)
+                  : (c <= 6314 || (c < 6400
+                    ? (c >= 6320 && c <= 6389)
+                    : c <= 6430)))))
+              : (c <= 6443 || (c < 6608
+                ? (c < 6512
+                  ? (c < 6470
+                    ? (c >= 6448 && c <= 6459)
+                    : c <= 6509)
+                  : (c <= 6516 || (c < 6576
+                    ? (c >= 6528 && c <= 6571)
+                    : c <= 6601)))
+                : (c <= 6618 || (c < 6752
+                  ? (c < 6688
+                    ? (c >= 6656 && c <= 6683)
+                    : c <= 6750)
+                  : (c <= 6780 || (c < 6800
+                    ? (c >= 6783 && c <= 6793)
+                    : c <= 6809)))))))
+            : (c <= 6823 || (c < 7357
+              ? (c < 7040
+                ? (c < 6912
+                  ? (c < 6847
+                    ? (c >= 6832 && c <= 6845)
+                    : c <= 6862)
+                  : (c <= 6988 || (c < 7019
+                    ? (c >= 6992 && c <= 7001)
+                    : c <= 7027)))
+                : (c <= 7155 || (c < 7245
+                  ? (c < 7232
+                    ? (c >= 7168 && c <= 7223)
+                    : c <= 7241)
+                  : (c <= 7293 || (c < 7312
+                    ? (c >= 7296 && c <= 7304)
+                    : c <= 7354)))))
+              : (c <= 7359 || (c < 8008
+                ? (c < 7424
+                  ? (c < 7380
+                    ? (c >= 7376 && c <= 7378)
+                    : c <= 7418)
+                  : (c <= 7957 || (c < 7968
+                    ? (c >= 7960 && c <= 7965)
+                    : c <= 8005)))
+                : (c <= 8013 || (c < 8027
+                  ? (c < 8025
+                    ? (c >= 8016 && c <= 8023)
+                    : c <= 8025)
+                  : (c <= 8027 || (c < 8031
+                    ? c == 8029
+                    : c <= 8061)))))))))))
+        : (c <= 8116 || (c < 12321
+          ? (c < 8488
+            ? (c < 8319
+              ? (c < 8160
+                ? (c < 8134
+                  ? (c < 8126
+                    ? (c >= 8118 && c <= 8124)
+                    : (c <= 8126 || (c >= 8130 && c <= 8132)))
+                  : (c <= 8140 || (c < 8150
+                    ? (c >= 8144 && c <= 8147)
+                    : c <= 8155)))
+                : (c <= 8172 || (c < 8255
+                  ? (c < 8182
+                    ? (c >= 8178 && c <= 8180)
+                    : c <= 8188)
+                  : (c <= 8256 || (c < 8305
+                    ? c == 8276
+                    : c <= 8305)))))
+              : (c <= 8319 || (c < 8455
+                ? (c < 8417
+                  ? (c < 8400
+                    ? (c >= 8336 && c <= 8348)
+                    : c <= 8412)
+                  : (c <= 8417 || (c < 8450
+                    ? (c >= 8421 && c <= 8432)
+                    : c <= 8450)))
+                : (c <= 8455 || (c < 8472
+                  ? (c < 8469
+                    ? (c >= 8458 && c <= 8467)
+                    : c <= 8469)
+                  : (c <= 8477 || (c < 8486
+                    ? c == 8484
+                    : c <= 8486)))))))
+            : (c <= 8488 || (c < 11631
+              ? (c < 11264
+                ? (c < 8517
+                  ? (c < 8508
+                    ? (c >= 8490 && c <= 8505)
+                    : c <= 8511)
+                  : (c <= 8521 || (c < 8544
+                    ? c == 8526
+                    : c <= 8584)))
+                : (c <= 11492 || (c < 11559
+                  ? (c < 11520
+                    ? (c >= 11499 && c <= 11507)
+                    : c <= 11557)
+                  : (c <= 11559 || (c < 11568
+                    ? c == 11565
+                    : c <= 11623)))))
+              : (c <= 11631 || (c < 11712
+                ? (c < 11688
+                  ? (c < 11680
+                    ? (c >= 11647 && c <= 11670)
+                    : c <= 11686)
+                  : (c <= 11694 || (c < 11704
+                    ? (c >= 11696 && c <= 11702)
+                    : c <= 11710)))
+                : (c <= 11718 || (c < 11736
+                  ? (c < 11728
+                    ? (c >= 11720 && c <= 11726)
+                    : c <= 11734)
+                  : (c <= 11742 || (c < 12293
+                    ? (c >= 11744 && c <= 11775)
+                    : c <= 12295)))))))))
+          : (c <= 12335 || (c < 42963
+            ? (c < 13312
+              ? (c < 12449
+                ? (c < 12353
+                  ? (c < 12344
+                    ? (c >= 12337 && c <= 12341)
+                    : c <= 12348)
+                  : (c <= 12438 || (c < 12445
+                    ? (c >= 12441 && c <= 12442)
+                    : c <= 12447)))
+                : (c <= 12538 || (c < 12593
+                  ? (c < 12549
+                    ? (c >= 12540 && c <= 12543)
+                    : c <= 12591)
+                  : (c <= 12686 || (c < 12784
+                    ? (c >= 12704 && c <= 12735)
+                    : c <= 12799)))))
+              : (c <= 19903 || (c < 42612
+                ? (c < 42240
+                  ? (c < 42192
+                    ? (c >= 19968 && c <= 42124)
+                    : c <= 42237)
+                  : (c <= 42508 || (c < 42560
+                    ? (c >= 42512 && c <= 42539)
+                    : c <= 42607)))
+                : (c <= 42621 || (c < 42786
+                  ? (c < 42775
+                    ? (c >= 42623 && c <= 42737)
+                    : c <= 42783)
+                  : (c <= 42888 || (c < 42960
+                    ? (c >= 42891 && c <= 42954)
+                    : c <= 42961)))))))
+            : (c <= 42963 || (c < 43392
+              ? (c < 43216
+                ? (c < 43052
+                  ? (c < 42994
+                    ? (c >= 42965 && c <= 42969)
+                    : c <= 43047)
+                  : (c <= 43052 || (c < 43136
+                    ? (c >= 43072 && c <= 43123)
+                    : c <= 43205)))
+                : (c <= 43225 || (c < 43261
+                  ? (c < 43259
+                    ? (c >= 43232 && c <= 43255)
+                    : c <= 43259)
+                  : (c <= 43309 || (c < 43360
+                    ? (c >= 43312 && c <= 43347)
+                    : c <= 43388)))))
+              : (c <= 43456 || (c < 43616
+                ? (c < 43520
+                  ? (c < 43488
+                    ? (c >= 43471 && c <= 43481)
+                    : c <= 43518)
+                  : (c <= 43574 || (c < 43600
+                    ? (c >= 43584 && c <= 43597)
+                    : c <= 43609)))
+                : (c <= 43638 || (c < 43744
+                  ? (c < 43739
+                    ? (c >= 43642 && c <= 43714)
+                    : c <= 43741)
+                  : (c <= 43759 || (c < 43777
+                    ? (c >= 43762 && c <= 43766)
+                    : c <= 43782)))))))))))))))
+    : (c <= 43790 || (c < 71960
+      ? (c < 67840
+        ? (c < 65549
+          ? (c < 64848
+            ? (c < 64112
+              ? (c < 44012
+                ? (c < 43824
+                  ? (c < 43808
+                    ? (c >= 43793 && c <= 43798)
+                    : (c <= 43814 || (c >= 43816 && c <= 43822)))
+                  : (c <= 43866 || (c < 43888
+                    ? (c >= 43868 && c <= 43881)
+                    : c <= 44010)))
+                : (c <= 44013 || (c < 55216
+                  ? (c < 44032
+                    ? (c >= 44016 && c <= 44025)
+                    : c <= 55203)
+                  : (c <= 55238 || (c < 63744
+                    ? (c >= 55243 && c <= 55291)
+                    : c <= 64109)))))
+              : (c <= 64217 || (c < 64318
+                ? (c < 64285
+                  ? (c < 64275
+                    ? (c >= 64256 && c <= 64262)
+                    : c <= 64279)
+                  : (c <= 64296 || (c < 64312
+                    ? (c >= 64298 && c <= 64310)
+                    : c <= 64316)))
+                : (c <= 64318 || (c < 64326
+                  ? (c < 64323
+                    ? (c >= 64320 && c <= 64321)
+                    : c <= 64324)
+                  : (c <= 64433 || (c < 64612
+                    ? (c >= 64467 && c <= 64605)
+                    : c <= 64829)))))))
+            : (c <= 64911 || (c < 65149
+              ? (c < 65101
+                ? (c < 65024
+                  ? (c < 65008
+                    ? (c >= 64914 && c <= 64967)
+                    : c <= 65017)
+                  : (c <= 65039 || (c < 65075
+                    ? (c >= 65056 && c <= 65071)
+                    : c <= 65076)))
+                : (c <= 65103 || (c < 65143
+                  ? (c < 65139
+                    ? c == 65137
+                    : c <= 65139)
+                  : (c <= 65143 || (c < 65147
+                    ? c == 65145
+                    : c <= 65147)))))
+              : (c <= 65149 || (c < 65382
+                ? (c < 65313
+                  ? (c < 65296
+                    ? (c >= 65151 && c <= 65276)
+                    : c <= 65305)
+                  : (c <= 65338 || (c < 65345
+                    ? c == 65343
+                    : c <= 65370)))
+                : (c <= 65470 || (c < 65490
+                  ? (c < 65482
+                    ? (c >= 65474 && c <= 65479)
+                    : c <= 65487)
+                  : (c <= 65495 || (c < 65536
+                    ? (c >= 65498 && c <= 65500)
+                    : c <= 65547)))))))))
+          : (c <= 65574 || (c < 66928
+            ? (c < 66349
+              ? (c < 65856
+                ? (c < 65599
+                  ? (c < 65596
+                    ? (c >= 65576 && c <= 65594)
+                    : c <= 65597)
+                  : (c <= 65613 || (c < 65664
+                    ? (c >= 65616 && c <= 65629)
+                    : c <= 65786)))
+                : (c <= 65908 || (c < 66208
+                  ? (c < 66176
+                    ? c == 66045
+                    : c <= 66204)
+                  : (c <= 66256 || (c < 66304
+                    ? c == 66272
+                    : c <= 66335)))))
+              : (c <= 66378 || (c < 66560
+                ? (c < 66464
+                  ? (c < 66432
+                    ? (c >= 66384 && c <= 66426)
+                    : c <= 66461)
+                  : (c <= 66499 || (c < 66513
+                    ? (c >= 66504 && c <= 66511)
+                    : c <= 66517)))
+                : (c <= 66717 || (c < 66776
+                  ? (c < 66736
+                    ? (c >= 66720 && c <= 66729)
+                    : c <= 66771)
+                  : (c <= 66811 || (c < 66864
+                    ? (c >= 66816 && c <= 66855)
+                    : c <= 66915)))))))
+            : (c <= 66938 || (c < 67463
+              ? (c < 66995
+                ? (c < 66964
+                  ? (c < 66956
+                    ? (c >= 66940 && c <= 66954)
+                    : c <= 66962)
+                  : (c <= 66965 || (c < 66979
+                    ? (c >= 66967 && c <= 66977)
+                    : c <= 66993)))
+                : (c <= 67001 || (c < 67392
+                  ? (c < 67072
+                    ? (c >= 67003 && c <= 67004)
+                    : c <= 67382)
+                  : (c <= 67413 || (c < 67456
+                    ? (c >= 67424 && c <= 67431)
+                    : c <= 67461)))))
+              : (c <= 67504 || (c < 67644
+                ? (c < 67592
+                  ? (c < 67584
+                    ? (c >= 67506 && c <= 67514)
+                    : c <= 67589)
+                  : (c <= 67592 || (c < 67639
+                    ? (c >= 67594 && c <= 67637)
+                    : c <= 67640)))
+                : (c <= 67644 || (c < 67712
+                  ? (c < 67680
+                    ? (c >= 67647 && c <= 67669)
+                    : c <= 67702)
+                  : (c <= 67742 || (c < 67828
+                    ? (c >= 67808 && c <= 67826)
+                    : c <= 67829)))))))))))
+        : (c <= 67861 || (c < 70163
+          ? (c < 69291
+            ? (c < 68288
+              ? (c < 68117
+                ? (c < 68096
+                  ? (c < 67968
+                    ? (c >= 67872 && c <= 67897)
+                    : (c <= 68023 || (c >= 68030 && c <= 68031)))
+                  : (c <= 68099 || (c < 68108
+                    ? (c >= 68101 && c <= 68102)
+                    : c <= 68115)))
+                : (c <= 68119 || (c < 68159
+                  ? (c < 68152
+                    ? (c >= 68121 && c <= 68149)
+                    : c <= 68154)
+                  : (c <= 68159 || (c < 68224
+                    ? (c >= 68192 && c <= 68220)
+                    : c <= 68252)))))
+              : (c <= 68295 || (c < 68608
+                ? (c < 68416
+                  ? (c < 68352
+                    ? (c >= 68297 && c <= 68326)
+                    : c <= 68405)
+                  : (c <= 68437 || (c < 68480
+                    ? (c >= 68448 && c <= 68466)
+                    : c <= 68497)))
+                : (c <= 68680 || (c < 68864
+                  ? (c < 68800
+                    ? (c >= 68736 && c <= 68786)
+                    : c <= 68850)
+                  : (c <= 68903 || (c < 69248
+                    ? (c >= 68912 && c <= 68921)
+                    : c <= 69289)))))))
+            : (c <= 69292 || (c < 69840
+              ? (c < 69552
+                ? (c < 69415
+                  ? (c < 69373
+                    ? (c >= 69296 && c <= 69297)
+                    : c <= 69404)
+                  : (c <= 69415 || (c < 69488
+                    ? (c >= 69424 && c <= 69456)
+                    : c <= 69509)))
+                : (c <= 69572 || (c < 69734
+                  ? (c < 69632
+                    ? (c >= 69600 && c <= 69622)
+                    : c <= 69702)
+                  : (c <= 69749 || (c < 69826
+                    ? (c >= 69759 && c <= 69818)
+                    : c <= 69826)))))
+              : (c <= 69864 || (c < 70006
+                ? (c < 69942
+                  ? (c < 69888
+                    ? (c >= 69872 && c <= 69881)
+                    : c <= 69940)
+                  : (c <= 69951 || (c < 69968
+                    ? (c >= 69956 && c <= 69959)
+                    : c <= 70003)))
+                : (c <= 70006 || (c < 70094
+                  ? (c < 70089
+                    ? (c >= 70016 && c <= 70084)
+                    : c <= 70092)
+                  : (c <= 70106 || (c < 70144
+                    ? c == 70108
+                    : c <= 70161)))))))))
+          : (c <= 70199 || (c < 70656
+            ? (c < 70419
+              ? (c < 70303
+                ? (c < 70280
+                  ? (c < 70272
+                    ? (c >= 70206 && c <= 70209)
+                    : c <= 70278)
+                  : (c <= 70280 || (c < 70287
+                    ? (c >= 70282 && c <= 70285)
+                    : c <= 70301)))
+                : (c <= 70312 || (c < 70400
+                  ? (c < 70384
+                    ? (c >= 70320 && c <= 70378)
+                    : c <= 70393)
+                  : (c <= 70403 || (c < 70415
+                    ? (c >= 70405 && c <= 70412)
+                    : c <= 70416)))))
+              : (c <= 70440 || (c < 70475
+                ? (c < 70453
+                  ? (c < 70450
+                    ? (c >= 70442 && c <= 70448)
+                    : c <= 70451)
+                  : (c <= 70457 || (c < 70471
+                    ? (c >= 70459 && c <= 70468)
+                    : c <= 70472)))
+                : (c <= 70477 || (c < 70493
+                  ? (c < 70487
+                    ? c == 70480
+                    : c <= 70487)
+                  : (c <= 70499 || (c < 70512
+                    ? (c >= 70502 && c <= 70508)
+                    : c <= 70516)))))))
+            : (c <= 70730 || (c < 71296
+              ? (c < 71040
+                ? (c < 70784
+                  ? (c < 70750
+                    ? (c >= 70736 && c <= 70745)
+                    : c <= 70753)
+                  : (c <= 70853 || (c < 70864
+                    ? c == 70855
+                    : c <= 70873)))
+                : (c <= 71093 || (c < 71168
+                  ? (c < 71128
+                    ? (c >= 71096 && c <= 71104)
+                    : c <= 71133)
+                  : (c <= 71232 || (c < 71248
+                    ? c == 71236
+                    : c <= 71257)))))
+              : (c <= 71352 || (c < 71680
+                ? (c < 71453
+                  ? (c < 71424
+                    ? (c >= 71360 && c <= 71369)
+                    : c <= 71450)
+                  : (c <= 71467 || (c < 71488
+                    ? (c >= 71472 && c <= 71481)
+                    : c <= 71494)))
+                : (c <= 71738 || (c < 71945
+                  ? (c < 71935
+                    ? (c >= 71840 && c <= 71913)
+                    : c <= 71942)
+                  : (c <= 71945 || (c < 71957
+                    ? (c >= 71948 && c <= 71955)
+                    : c <= 71958)))))))))))))
+      : (c <= 71989 || (c < 119995
+        ? (c < 92784
+          ? (c < 73023
+            ? (c < 72704
+              ? (c < 72163
+                ? (c < 72096
+                  ? (c < 71995
+                    ? (c >= 71991 && c <= 71992)
+                    : (c <= 72003 || (c >= 72016 && c <= 72025)))
+                  : (c <= 72103 || (c < 72154
+                    ? (c >= 72106 && c <= 72151)
+                    : c <= 72161)))
+                : (c <= 72164 || (c < 72272
+                  ? (c < 72263
+                    ? (c >= 72192 && c <= 72254)
+                    : c <= 72263)
+                  : (c <= 72345 || (c < 72368
+                    ? c == 72349
+                    : c <= 72440)))))
+              : (c <= 72712 || (c < 72873
+                ? (c < 72784
+                  ? (c < 72760
+                    ? (c >= 72714 && c <= 72758)
+                    : c <= 72768)
+                  : (c <= 72793 || (c < 72850
+                    ? (c >= 72818 && c <= 72847)
+                    : c <= 72871)))
+                : (c <= 72886 || (c < 72971
+                  ? (c < 72968
+                    ? (c >= 72960 && c <= 72966)
+                    : c <= 72969)
+                  : (c <= 73014 || (c < 73020
+                    ? c == 73018
+                    : c <= 73021)))))))
+            : (c <= 73031 || (c < 73552
+              ? (c < 73107
+                ? (c < 73063
+                  ? (c < 73056
+                    ? (c >= 73040 && c <= 73049)
+                    : c <= 73061)
+                  : (c <= 73064 || (c < 73104
+                    ? (c >= 73066 && c <= 73102)
+                    : c <= 73105)))
+                : (c <= 73112 || (c < 73472
+                  ? (c < 73440
+                    ? (c >= 73120 && c <= 73129)
+                    : c <= 73462)
+                  : (c <= 73488 || (c < 73534
+                    ? (c >= 73490 && c <= 73530)
+                    : c <= 73538)))))
+              : (c <= 73561 || (c < 77824
+                ? (c < 74752
+                  ? (c < 73728
+                    ? c == 73648
+                    : c <= 74649)
+                  : (c <= 74862 || (c < 77712
+                    ? (c >= 74880 && c <= 75075)
+                    : c <= 77808)))
+                : (c <= 78895 || (c < 92160
+                  ? (c < 82944
+                    ? (c >= 78912 && c <= 78933)
+                    : c <= 83526)
+                  : (c <= 92728 || (c < 92768
+                    ? (c >= 92736 && c <= 92766)
+                    : c <= 92777)))))))))
+          : (c <= 92862 || (c < 110928
+            ? (c < 94095
+              ? (c < 93008
+                ? (c < 92912
+                  ? (c < 92880
+                    ? (c >= 92864 && c <= 92873)
+                    : c <= 92909)
+                  : (c <= 92916 || (c < 92992
+                    ? (c >= 92928 && c <= 92982)
+                    : c <= 92995)))
+                : (c <= 93017 || (c < 93760
+                  ? (c < 93053
+                    ? (c >= 93027 && c <= 93047)
+                    : c <= 93071)
+                  : (c <= 93823 || (c < 94031
+                    ? (c >= 93952 && c <= 94026)
+                    : c <= 94087)))))
+              : (c <= 94111 || (c < 101632
+                ? (c < 94192
+                  ? (c < 94179
+                    ? (c >= 94176 && c <= 94177)
+                    : c <= 94180)
+                  : (c <= 94193 || (c < 100352
+                    ? (c >= 94208 && c <= 100343)
+                    : c <= 101589)))
+                : (c <= 101640 || (c < 110589
+                  ? (c < 110581
+                    ? (c >= 110576 && c <= 110579)
+                    : c <= 110587)
+                  : (c <= 110590 || (c < 110898
+                    ? (c >= 110592 && c <= 110882)
+                    : c <= 110898)))))))
+            : (c <= 110930 || (c < 119149
+              ? (c < 113792
+                ? (c < 110960
+                  ? (c < 110948
+                    ? c == 110933
+                    : c <= 110951)
+                  : (c <= 111355 || (c < 113776
+                    ? (c >= 113664 && c <= 113770)
+                    : c <= 113788)))
+                : (c <= 113800 || (c < 118528
+                  ? (c < 113821
+                    ? (c >= 113808 && c <= 113817)
+                    : c <= 113822)
+                  : (c <= 118573 || (c < 119141
+                    ? (c >= 118576 && c <= 118598)
+                    : c <= 119145)))))
+              : (c <= 119154 || (c < 119894
+                ? (c < 119210
+                  ? (c < 119173
+                    ? (c >= 119163 && c <= 119170)
+                    : c <= 119179)
+                  : (c <= 119213 || (c < 119808
+                    ? (c >= 119362 && c <= 119364)
+                    : c <= 119892)))
+                : (c <= 119964 || (c < 119973
+                  ? (c < 119970
+                    ? (c >= 119966 && c <= 119967)
+                    : c <= 119970)
+                  : (c <= 119974 || (c < 119982
+                    ? (c >= 119977 && c <= 119980)
+                    : c <= 119993)))))))))))
+        : (c <= 119995 || (c < 124912
+          ? (c < 121403
+            ? (c < 120514
+              ? (c < 120123
+                ? (c < 120077
+                  ? (c < 120005
+                    ? (c >= 119997 && c <= 120003)
+                    : (c <= 120069 || (c >= 120071 && c <= 120074)))
+                  : (c <= 120084 || (c < 120094
+                    ? (c >= 120086 && c <= 120092)
+                    : c <= 120121)))
+                : (c <= 120126 || (c < 120138
+                  ? (c < 120134
+                    ? (c >= 120128 && c <= 120132)
+                    : c <= 120134)
+                  : (c <= 120144 || (c < 120488
+                    ? (c >= 120146 && c <= 120485)
+                    : c <= 120512)))))
+              : (c <= 120538 || (c < 120688
+                ? (c < 120598
+                  ? (c < 120572
+                    ? (c >= 120540 && c <= 120570)
+                    : c <= 120596)
+                  : (c <= 120628 || (c < 120656
+                    ? (c >= 120630 && c <= 120654)
+                    : c <= 120686)))
+                : (c <= 120712 || (c < 120772
+                  ? (c < 120746
+                    ? (c >= 120714 && c <= 120744)
+                    : c <= 120770)
+                  : (c <= 120779 || (c < 121344
+                    ? (c >= 120782 && c <= 120831)
+                    : c <= 121398)))))))
+            : (c <= 121452 || (c < 122928
+              ? (c < 122661
+                ? (c < 121499
+                  ? (c < 121476
+                    ? c == 121461
+                    : c <= 121476)
+                  : (c <= 121503 || (c < 122624
+                    ? (c >= 121505 && c <= 121519)
+                    : c <= 122654)))
+                : (c <= 122666 || (c < 122907
+                  ? (c < 122888
                     ? (c >= 122880 && c <= 122886)
-                    : c <= 122904)))))
-              : (c <= 122913 || (c < 123214
-                ? (c < 123136
-                  ? (c < 122918
+                    : c <= 122904)
+                  : (c <= 122913 || (c < 122918
                     ? (c >= 122915 && c <= 122916)
-                    : c <= 122922)
-                  : (c <= 123180 || (c < 123200
-                    ? (c >= 123184 && c <= 123197)
-                    : c <= 123209)))
-                : (c <= 123214 || (c < 124896
-                  ? (c < 123584
-                    ? (c >= 123536 && c <= 123566)
-                    : c <= 123641)
+                    : c <= 122922)))))
+              : (c <= 122989 || (c < 123536
+                ? (c < 123184
+                  ? (c < 123136
+                    ? c == 123023
+                    : c <= 123180)
+                  : (c <= 123197 || (c < 123214
+                    ? (c >= 123200 && c <= 123209)
+                    : c <= 123214)))
+                : (c <= 123566 || (c < 124896
+                  ? (c < 124112
+                    ? (c >= 123584 && c <= 123641)
+                    : c <= 124153)
                   : (c <= 124902 || (c < 124909
                     ? (c >= 124904 && c <= 124907)
                     : c <= 124910)))))))))
@@ -7442,13 +7487,15 @@ static inline bool sym_identifier_character_set_3(int32_t c) {
                     ? (c >= 126635 && c <= 126651)
                     : c <= 130041)
                   : (c <= 173791 || (c < 177984
-                    ? (c >= 173824 && c <= 177976)
+                    ? (c >= 173824 && c <= 177977)
                     : c <= 178205)))
                 : (c <= 183969 || (c < 196608
                   ? (c < 194560
                     ? (c >= 183984 && c <= 191456)
                     : c <= 195101)
-                  : (c <= 201546 || (c >= 917760 && c <= 917999)))))))))))))))));
+                  : (c <= 201546 || (c < 917760
+                    ? (c >= 201552 && c <= 205743)
+                    : c <= 917999)))))))))))))))));
 }
 
 static bool ts_lex(TSLexer *lexer, TSStateId state) {
@@ -106313,17 +106360,17 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1030] = {.entry = {.count = 1, .reusable = false}}, SHIFT(552),
   [1032] = {.entry = {.count = 1, .reusable = true}}, SHIFT(90),
   [1034] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_list, 2),
-  [1036] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 7, .production_id = 110),
+  [1036] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 7, .production_id = 109),
   [1038] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1396),
-  [1040] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 7, .production_id = 110),
-  [1042] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 6, .production_id = 98),
-  [1044] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 98),
-  [1046] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 6, .production_id = 99),
-  [1048] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 99),
+  [1040] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 7, .production_id = 109),
+  [1042] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 6, .production_id = 97),
+  [1044] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 97),
+  [1046] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 6, .production_id = 98),
+  [1048] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 98),
   [1050] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1389),
   [1052] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1383),
-  [1054] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 5, .production_id = 84),
-  [1056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 84),
+  [1054] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_in_clause, 5, .production_id = 83),
+  [1056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 83),
   [1058] = {.entry = {.count = 1, .reusable = true}}, SHIFT(87),
   [1060] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_list, 3),
   [1062] = {.entry = {.count = 1, .reusable = true}}, SHIFT(125),
@@ -106390,17 +106437,17 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1184] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1154),
   [1186] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1148),
   [1188] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_return_statement, 1),
-  [1190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, .production_id = 69),
-  [1192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 5, .production_id = 69),
+  [1190] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, .production_id = 68),
+  [1192] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 5, .production_id = 68),
   [1194] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2175),
   [1196] = {.entry = {.count = 1, .reusable = true}}, SHIFT(485),
   [1198] = {.entry = {.count = 1, .reusable = false}}, SHIFT(2125),
-  [1200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 4, .production_id = 48),
-  [1202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 4, .production_id = 48),
+  [1200] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 4, .production_id = 47),
+  [1202] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 4, .production_id = 47),
   [1204] = {.entry = {.count = 1, .reusable = false}}, SHIFT(425),
   [1206] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_clause, 2),
-  [1208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 4, .production_id = 18),
-  [1210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 4, .production_id = 19),
+  [1208] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 4, .production_id = 17),
+  [1210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 4, .production_id = 18),
   [1212] = {.entry = {.count = 1, .reusable = true}}, SHIFT(204),
   [1214] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2056),
   [1216] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_statement, 3),
@@ -106421,29 +106468,29 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1247] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__named_expression_lhs, 1),
   [1249] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_pattern, 1),
   [1251] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pattern, 1),
-  [1253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 5, .production_id = 77),
-  [1255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 5, .production_id = 77),
+  [1253] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 5, .production_id = 76),
+  [1255] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 5, .production_id = 76),
   [1257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(638),
   [1259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(611),
-  [1261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 5, .production_id = 54),
-  [1263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 5, .production_id = 54),
-  [1265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 6, .production_id = 77),
-  [1267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 6, .production_id = 77),
+  [1261] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 5, .production_id = 53),
+  [1263] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 5, .production_id = 53),
+  [1265] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 6, .production_id = 76),
+  [1267] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 6, .production_id = 76),
   [1269] = {.entry = {.count = 1, .reusable = true}}, SHIFT(94),
   [1271] = {.entry = {.count = 1, .reusable = true}}, SHIFT(114),
   [1273] = {.entry = {.count = 1, .reusable = true}}, SHIFT(621),
-  [1275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3, .production_id = 28),
-  [1277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute, 3, .production_id = 28),
+  [1275] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_attribute, 3, .production_id = 27),
+  [1277] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_attribute, 3, .production_id = 27),
   [1279] = {.entry = {.count = 1, .reusable = true}}, SHIFT(634),
-  [1281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 4, .production_id = 54),
-  [1283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 4, .production_id = 54),
-  [1285] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 61),
-  [1287] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 61),
+  [1281] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_subscript, 4, .production_id = 53),
+  [1283] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_subscript, 4, .production_id = 53),
+  [1285] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 60),
+  [1287] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 60),
   [1289] = {.entry = {.count = 1, .reusable = false}}, SHIFT(459),
-  [1291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 62),
-  [1293] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 62),
-  [1295] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 4, .production_id = 42),
-  [1297] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 4, .production_id = 42),
+  [1291] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 61),
+  [1293] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 61),
+  [1295] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 4, .production_id = 41),
+  [1297] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 4, .production_id = 41),
   [1299] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_try_statement_repeat1, 2),
   [1301] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_try_statement_repeat1, 2),
   [1303] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_try_statement_repeat1, 2), SHIFT_REPEAT(425),
@@ -106461,8 +106508,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1330] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1306),
   [1332] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1313),
   [1334] = {.entry = {.count = 1, .reusable = false}}, SHIFT(174),
-  [1336] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 87),
-  [1338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 87),
+  [1336] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 86),
+  [1338] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 86),
   [1340] = {.entry = {.count = 1, .reusable = false}}, SHIFT(445),
   [1342] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_try_statement_repeat2, 2), SHIFT_REPEAT(457),
   [1345] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_try_statement_repeat1, 2), SHIFT_REPEAT(424),
@@ -106473,189 +106520,189 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1357] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_pattern, 2),
   [1359] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__simple_statements, 4),
   [1361] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__simple_statements, 4),
-  [1363] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 64),
-  [1365] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 64),
-  [1367] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 64), SHIFT_REPEAT(445),
+  [1363] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 63),
+  [1365] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 63),
+  [1367] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 63), SHIFT_REPEAT(445),
   [1370] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__simple_statements, 3),
   [1372] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__simple_statements, 3),
   [1374] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 1),
   [1376] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 1),
   [1378] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__simple_statements, 2),
   [1380] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym__simple_statements, 2),
-  [1382] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 64), SHIFT_REPEAT(459),
+  [1382] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 2, .production_id = 63), SHIFT_REPEAT(459),
   [1385] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_block, 2),
   [1387] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_block, 2),
   [1389] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 5),
   [1391] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 5),
-  [1393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 6, .production_id = 88),
-  [1395] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 6, .production_id = 88),
+  [1393] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 6, .production_id = 87),
+  [1395] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 6, .production_id = 87),
   [1397] = {.entry = {.count = 1, .reusable = false}}, SHIFT(363),
-  [1399] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 65),
-  [1401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 65),
+  [1399] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 64),
+  [1401] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 64),
   [1403] = {.entry = {.count = 1, .reusable = false}}, SHIFT(359),
-  [1405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 3, .production_id = 93),
-  [1407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 3, .production_id = 93),
+  [1405] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 3, .production_id = 92),
+  [1407] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 3, .production_id = 92),
   [1409] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 4),
   [1411] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 4),
-  [1413] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 4, .production_id = 108),
-  [1415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 4, .production_id = 108),
-  [1417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 4, .production_id = 108),
-  [1419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 4, .production_id = 108),
+  [1413] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 4, .production_id = 107),
+  [1415] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 4, .production_id = 107),
+  [1417] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 4, .production_id = 107),
+  [1419] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 4, .production_id = 107),
   [1421] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 5),
   [1423] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 5),
-  [1425] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 6, .production_id = 128),
-  [1427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 6, .production_id = 128),
-  [1429] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 6, .production_id = 128),
-  [1431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 6, .production_id = 128),
+  [1425] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 6, .production_id = 127),
+  [1427] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 6, .production_id = 127),
+  [1429] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 6, .production_id = 127),
+  [1431] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 6, .production_id = 127),
   [1433] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_clause, 7),
   [1435] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_clause, 7),
   [1437] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_except_group_clause, 7),
   [1439] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_except_group_clause, 7),
-  [1441] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 44),
-  [1443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 44),
-  [1445] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 21),
-  [1447] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 21),
-  [1449] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 64),
-  [1451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 64),
-  [1453] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 64), SHIFT_REPEAT(359),
-  [1456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 3, .production_id = 21),
-  [1458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 3, .production_id = 21),
-  [1460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 63),
-  [1462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 63),
-  [1464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 45),
-  [1466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 45),
-  [1468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 45),
-  [1470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 45),
-  [1472] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 64), SHIFT_REPEAT(363),
-  [1475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 6, .production_id = 91),
-  [1477] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 6, .production_id = 91),
-  [1479] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_clause, 5, .production_id = 62),
-  [1481] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_clause, 5, .production_id = 62),
-  [1483] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 1, .production_id = 43),
-  [1485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_if_statement_repeat1, 1, .production_id = 43),
-  [1487] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 5, .production_id = 48),
-  [1489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, .production_id = 48),
-  [1491] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 5, .production_id = 68),
-  [1493] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, .production_id = 68),
-  [1495] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 6, .production_id = 69),
-  [1497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, .production_id = 69),
-  [1499] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 4, .production_id = 47),
-  [1501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 4, .production_id = 47),
-  [1503] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 104),
-  [1505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 104),
-  [1507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 116),
-  [1509] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 116),
-  [1511] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 107),
-  [1513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 107),
-  [1515] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_clause, 4, .production_id = 42),
-  [1517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_clause, 4, .production_id = 42),
-  [1519] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 114),
-  [1521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 114),
-  [1523] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 111),
-  [1525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 111),
-  [1527] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 112),
-  [1529] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 112),
-  [1531] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 120),
-  [1533] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 120),
-  [1535] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 121),
-  [1537] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 121),
-  [1539] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_clause, 3, .production_id = 48),
-  [1541] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_clause, 3, .production_id = 48),
-  [1543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 122),
-  [1545] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 122),
-  [1547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 123),
-  [1549] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 123),
-  [1551] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 4, .production_id = 102),
-  [1553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 4, .production_id = 102),
-  [1555] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 124),
-  [1557] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 124),
-  [1559] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 125),
-  [1561] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 125),
-  [1563] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 1, .production_id = 43),
-  [1565] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat2, 1, .production_id = 43),
-  [1567] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_clause, 4, .production_id = 69),
-  [1569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_clause, 4, .production_id = 69),
-  [1571] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 113),
-  [1573] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 113),
-  [1575] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 129),
-  [1577] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 129),
-  [1579] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 130),
-  [1581] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 130),
-  [1583] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 131),
-  [1585] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 131),
-  [1587] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 132),
-  [1589] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 132),
-  [1591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 8, .production_id = 133),
-  [1593] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 8, .production_id = 133),
-  [1595] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 7, .production_id = 105),
-  [1597] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 7, .production_id = 105),
-  [1599] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 6, .production_id = 92),
-  [1601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 6, .production_id = 92),
-  [1603] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 6, .production_id = 90),
-  [1605] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 6, .production_id = 90),
+  [1441] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 43),
+  [1443] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 43),
+  [1445] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 20),
+  [1447] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 20),
+  [1449] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 63),
+  [1451] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 63),
+  [1453] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 63), SHIFT_REPEAT(359),
+  [1456] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 3, .production_id = 20),
+  [1458] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 3, .production_id = 20),
+  [1460] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 62),
+  [1462] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 62),
+  [1464] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 5, .production_id = 44),
+  [1466] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 5, .production_id = 44),
+  [1468] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_match_statement, 4, .production_id = 44),
+  [1470] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_match_statement, 4, .production_id = 44),
+  [1472] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 2, .production_id = 63), SHIFT_REPEAT(363),
+  [1475] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 6, .production_id = 90),
+  [1477] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 6, .production_id = 90),
+  [1479] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_clause, 5, .production_id = 61),
+  [1481] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_clause, 5, .production_id = 61),
+  [1483] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_if_statement_repeat1, 1, .production_id = 42),
+  [1485] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_if_statement_repeat1, 1, .production_id = 42),
+  [1487] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 5, .production_id = 47),
+  [1489] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 5, .production_id = 47),
+  [1491] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 5, .production_id = 67),
+  [1493] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, .production_id = 67),
+  [1495] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 6, .production_id = 68),
+  [1497] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, .production_id = 68),
+  [1499] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 4, .production_id = 46),
+  [1501] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 4, .production_id = 46),
+  [1503] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 103),
+  [1505] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 103),
+  [1507] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 115),
+  [1509] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 115),
+  [1511] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 106),
+  [1513] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 106),
+  [1515] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_elif_clause, 4, .production_id = 41),
+  [1517] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_elif_clause, 4, .production_id = 41),
+  [1519] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 113),
+  [1521] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 113),
+  [1523] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 110),
+  [1525] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 110),
+  [1527] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 111),
+  [1529] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 111),
+  [1531] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 119),
+  [1533] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 119),
+  [1535] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 120),
+  [1537] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 120),
+  [1539] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_clause, 3, .production_id = 47),
+  [1541] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_clause, 3, .production_id = 47),
+  [1543] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 121),
+  [1545] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 121),
+  [1547] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 122),
+  [1549] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 122),
+  [1551] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 4, .production_id = 101),
+  [1553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 4, .production_id = 101),
+  [1555] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 123),
+  [1557] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 123),
+  [1559] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 6, .production_id = 124),
+  [1561] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 6, .production_id = 124),
+  [1563] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_match_statement_repeat2, 1, .production_id = 42),
+  [1565] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat2, 1, .production_id = 42),
+  [1567] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_else_clause, 4, .production_id = 68),
+  [1569] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_else_clause, 4, .production_id = 68),
+  [1571] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 5, .production_id = 112),
+  [1573] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 5, .production_id = 112),
+  [1575] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 128),
+  [1577] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 128),
+  [1579] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 129),
+  [1581] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 129),
+  [1583] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 130),
+  [1585] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 130),
+  [1587] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 7, .production_id = 131),
+  [1589] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 7, .production_id = 131),
+  [1591] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_case_clause, 8, .production_id = 132),
+  [1593] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_case_clause, 8, .production_id = 132),
+  [1595] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 7, .production_id = 104),
+  [1597] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 7, .production_id = 104),
+  [1599] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 6, .production_id = 91),
+  [1601] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 6, .production_id = 91),
+  [1603] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 6, .production_id = 89),
+  [1605] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 6, .production_id = 89),
   [1607] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_finally_clause, 4),
   [1609] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_finally_clause, 4),
-  [1611] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 60),
-  [1613] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 60),
-  [1615] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 9, .production_id = 126),
-  [1617] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 9, .production_id = 126),
-  [1619] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 6, .production_id = 94),
-  [1621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 6, .production_id = 94),
-  [1623] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 85),
-  [1625] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 85),
+  [1611] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 5, .production_id = 59),
+  [1613] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 5, .production_id = 59),
+  [1615] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 9, .production_id = 125),
+  [1617] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 9, .production_id = 125),
+  [1619] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 6, .production_id = 93),
+  [1621] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 6, .production_id = 93),
+  [1623] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 84),
+  [1625] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 84),
   [1627] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1374),
   [1629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(186),
   [1631] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1973),
   [1633] = {.entry = {.count = 1, .reusable = true}}, SHIFT(979),
   [1635] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1381),
   [1637] = {.entry = {.count = 1, .reusable = true}}, SHIFT(175),
-  [1639] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 5, .production_id = 67),
-  [1641] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, .production_id = 67),
-  [1643] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 7, .production_id = 69),
-  [1645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 7, .production_id = 69),
-  [1647] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 5, .production_id = 66),
-  [1649] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 5, .production_id = 66),
-  [1651] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 86),
-  [1653] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 86),
-  [1655] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 5, .production_id = 73),
-  [1657] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 5, .production_id = 73),
-  [1659] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 5, .production_id = 72),
-  [1661] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 5, .production_id = 72),
-  [1663] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, .production_id = 100),
-  [1665] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 7, .production_id = 100),
-  [1667] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 7, .production_id = 109),
-  [1669] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 7, .production_id = 109),
-  [1671] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 4, .production_id = 49),
-  [1673] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 4, .production_id = 49),
-  [1675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 6, .production_id = 89),
-  [1677] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 6, .production_id = 89),
-  [1679] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_decorated_definition, 2, .production_id = 14),
-  [1681] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_decorated_definition, 2, .production_id = 14),
-  [1683] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 118),
-  [1685] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 118),
-  [1687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 5, .production_id = 70),
-  [1689] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 5, .production_id = 70),
-  [1691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 5, .production_id = 71),
-  [1693] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 5, .production_id = 71),
-  [1695] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 4, .production_id = 50),
-  [1697] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 4, .production_id = 50),
-  [1699] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 9, .production_id = 127),
-  [1701] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 9, .production_id = 127),
+  [1639] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_while_statement, 5, .production_id = 66),
+  [1641] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_while_statement, 5, .production_id = 66),
+  [1643] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 7, .production_id = 68),
+  [1645] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 7, .production_id = 68),
+  [1647] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 5, .production_id = 65),
+  [1649] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 5, .production_id = 65),
+  [1651] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 6, .production_id = 85),
+  [1653] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 6, .production_id = 85),
+  [1655] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 5, .production_id = 72),
+  [1657] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 5, .production_id = 72),
+  [1659] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 5, .production_id = 71),
+  [1661] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 5, .production_id = 71),
+  [1663] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_if_statement, 7, .production_id = 99),
+  [1665] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_if_statement, 7, .production_id = 99),
+  [1667] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 7, .production_id = 108),
+  [1669] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 7, .production_id = 108),
+  [1671] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 4, .production_id = 48),
+  [1673] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 4, .production_id = 48),
+  [1675] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 6, .production_id = 88),
+  [1677] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 6, .production_id = 88),
+  [1679] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_decorated_definition, 2, .production_id = 13),
+  [1681] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_decorated_definition, 2, .production_id = 13),
+  [1683] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 117),
+  [1685] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 117),
+  [1687] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_statement, 5, .production_id = 69),
+  [1689] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_with_statement, 5, .production_id = 69),
+  [1691] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 5, .production_id = 70),
+  [1693] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 5, .production_id = 70),
+  [1695] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 4, .production_id = 49),
+  [1697] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 4, .production_id = 49),
+  [1699] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 9, .production_id = 126),
+  [1701] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 9, .production_id = 126),
   [1703] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1968),
-  [1705] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 115),
-  [1707] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 115),
-  [1709] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_finally_clause, 3, .production_id = 93),
-  [1711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_finally_clause, 3, .production_id = 93),
-  [1713] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 8, .production_id = 117),
-  [1715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 8, .production_id = 117),
-  [1717] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 6, .production_id = 48),
-  [1719] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, .production_id = 48),
-  [1721] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 8, .production_id = 119),
-  [1723] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 8, .production_id = 119),
-  [1725] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 6, .production_id = 95),
-  [1727] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 6, .production_id = 95),
-  [1729] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 106),
-  [1731] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 106),
+  [1705] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 8, .production_id = 114),
+  [1707] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 8, .production_id = 114),
+  [1709] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_finally_clause, 3, .production_id = 92),
+  [1711] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_finally_clause, 3, .production_id = 92),
+  [1713] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 8, .production_id = 116),
+  [1715] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 8, .production_id = 116),
+  [1717] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_try_statement, 6, .production_id = 47),
+  [1719] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_try_statement, 6, .production_id = 47),
+  [1721] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_function_definition, 8, .production_id = 118),
+  [1723] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_function_definition, 8, .production_id = 118),
+  [1725] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_class_definition, 6, .production_id = 94),
+  [1727] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_class_definition, 6, .production_id = 94),
+  [1729] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_statement, 7, .production_id = 105),
+  [1731] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_for_statement, 7, .production_id = 105),
   [1733] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1368),
   [1735] = {.entry = {.count = 1, .reusable = true}}, SHIFT(181),
   [1737] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1023),
@@ -106722,17 +106769,17 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [1861] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1218),
   [1863] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1211),
   [1865] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_concatenated_string_repeat1, 2), SHIFT_REPEAT(1451),
-  [1868] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 55),
-  [1870] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 55),
-  [1872] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_operator, 2, .production_id = 11),
-  [1874] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unary_operator, 2, .production_id = 11),
-  [1876] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operator, 3, .production_id = 26),
-  [1878] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_operator, 3, .production_id = 26),
+  [1868] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 54),
+  [1870] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 54),
+  [1872] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_unary_operator, 2, .production_id = 10),
+  [1874] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_unary_operator, 2, .production_id = 10),
+  [1876] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_binary_operator, 3, .production_id = 25),
+  [1878] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_binary_operator, 3, .production_id = 25),
   [1880] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_concatenated_string_repeat1, 2), SHIFT_REPEAT(1449),
-  [1883] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29),
-  [1885] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29),
-  [1887] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 56),
-  [1889] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 56),
+  [1883] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 28),
+  [1885] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 28),
+  [1887] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 55),
+  [1889] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 3, .production_id = 55),
   [1891] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2143),
   [1893] = {.entry = {.count = 1, .reusable = true}}, SHIFT(206),
   [1895] = {.entry = {.count = 1, .reusable = false}}, SHIFT(908),
@@ -106814,8 +106861,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2050] = {.entry = {.count = 1, .reusable = true}}, SHIFT(880),
   [2052] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 2, .production_id = 2),
   [2054] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 2, .production_id = 2),
-  [2056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, .production_id = 15),
-  [2058] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3, .production_id = 15),
+  [2056] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_string, 3, .production_id = 14),
+  [2058] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_string, 3, .production_id = 14),
   [2060] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1380),
   [2062] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1367),
   [2064] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1359),
@@ -106839,14 +106886,14 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2100] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_concatenated_string_repeat1, 2), SHIFT_REPEAT(1448),
   [2103] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1378),
   [2105] = {.entry = {.count = 1, .reusable = false}}, SHIFT(1363),
-  [2107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_set_comprehension, 4, .production_id = 39),
-  [2109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_set_comprehension, 4, .production_id = 39),
+  [2107] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_set_comprehension, 4, .production_id = 38),
+  [2109] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_set_comprehension, 4, .production_id = 38),
   [2111] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_tuple, 3),
   [2113] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_tuple, 3),
   [2115] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list, 3),
   [2117] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list, 3),
-  [2119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_comprehension, 4, .production_id = 39),
-  [2121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_comprehension, 4, .production_id = 39),
+  [2119] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_comprehension, 4, .production_id = 38),
+  [2121] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_list_comprehension, 4, .production_id = 38),
   [2123] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 5),
   [2125] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 5),
   [2127] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 3),
@@ -106855,71 +106902,71 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2133] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_set, 3),
   [2135] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_expression, 3),
   [2137] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_parenthesized_expression, 3),
-  [2139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call, 2, .production_id = 12),
-  [2141] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_call, 2, .production_id = 12),
+  [2139] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_call, 2, .production_id = 11),
+  [2141] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_call, 2, .production_id = 11),
   [2143] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 4),
   [2145] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 4),
   [2147] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 2),
   [2149] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 2),
-  [2151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 5, .production_id = 38),
-  [2153] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 5, .production_id = 38),
-  [2155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 3, .production_id = 38),
-  [2157] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 3, .production_id = 38),
+  [2151] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 5, .production_id = 37),
+  [2153] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 5, .production_id = 37),
+  [2155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 3, .production_id = 37),
+  [2157] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 3, .production_id = 37),
   [2159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 5),
   [2161] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 5),
   [2163] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 3),
   [2165] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 3),
   [2167] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 2),
   [2169] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 2),
-  [2171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 4, .production_id = 38),
-  [2173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 4, .production_id = 38),
-  [2175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_generator_expression, 4, .production_id = 39),
-  [2177] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_generator_expression, 4, .production_id = 39),
-  [2179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_comprehension, 4, .production_id = 39),
-  [2181] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_comprehension, 4, .production_id = 39),
+  [2171] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_argument_list, 4, .production_id = 37),
+  [2173] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_argument_list, 4, .production_id = 37),
+  [2175] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_generator_expression, 4, .production_id = 38),
+  [2177] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_generator_expression, 4, .production_id = 38),
+  [2179] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_comprehension, 4, .production_id = 38),
+  [2181] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary_comprehension, 4, .production_id = 38),
   [2183] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary, 4),
   [2185] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_dictionary, 4),
   [2187] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_splat_pattern, 2, .production_id = 7),
   [2189] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_splat_pattern, 2),
   [2191] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_primary_expression, 1), REDUCE(sym_list_splat_pattern, 2),
-  [2194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30),
-  [2196] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30),
-  [2198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(1005),
-  [2201] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2118),
-  [2204] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(1005),
-  [2207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(868),
-  [2210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comparison_operator, 2, .production_id = 13),
-  [2212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comparison_operator, 2, .production_id = 13),
-  [2214] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(975),
-  [2217] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2174),
-  [2220] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(975),
-  [2223] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(871),
-  [2226] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(978),
-  [2229] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2063),
-  [2232] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(978),
-  [2235] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(885),
-  [2238] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(1036),
-  [2241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2160),
-  [2244] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(1036),
-  [2247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(878),
-  [2250] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(911),
-  [2253] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2130),
-  [2256] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(911),
-  [2259] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(882),
-  [2262] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(931),
-  [2265] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2075),
-  [2268] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(931),
-  [2271] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(888),
+  [2194] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29),
+  [2196] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29),
+  [2198] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(1005),
+  [2201] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2118),
+  [2204] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(1005),
+  [2207] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(868),
+  [2210] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_comparison_operator, 2, .production_id = 12),
+  [2212] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_comparison_operator, 2, .production_id = 12),
+  [2214] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(975),
+  [2217] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2174),
+  [2220] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(975),
+  [2223] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(871),
+  [2226] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(978),
+  [2229] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2063),
+  [2232] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(978),
+  [2235] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(885),
+  [2238] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(1036),
+  [2241] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2160),
+  [2244] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(1036),
+  [2247] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(878),
+  [2250] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(911),
+  [2253] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2130),
+  [2256] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(911),
+  [2259] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(882),
+  [2262] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(931),
+  [2265] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2075),
+  [2268] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(931),
+  [2271] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(888),
   [2274] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_splat_pattern, 2),
   [2276] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_splat_pattern, 2, .production_id = 7),
-  [2278] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(927),
-  [2281] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2049),
-  [2284] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(927),
-  [2287] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(880),
-  [2290] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(963),
-  [2293] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(2087),
-  [2296] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(963),
-  [2299] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 30), SHIFT_REPEAT(869),
+  [2278] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(927),
+  [2281] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2049),
+  [2284] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(927),
+  [2287] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(880),
+  [2290] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(963),
+  [2293] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(2087),
+  [2296] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(963),
+  [2299] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_comparison_operator_repeat1, 2, .production_id = 29), SHIFT_REPEAT(869),
   [2302] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__patterns_repeat1, 2), SHIFT_REPEAT(829),
   [2305] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__patterns_repeat1, 2),
   [2307] = {.entry = {.count = 1, .reusable = true}}, SHIFT(198),
@@ -106994,7 +107041,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2445] = {.entry = {.count = 1, .reusable = true}}, SHIFT(264),
   [2447] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1102),
   [2449] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1244),
-  [2451] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_with_item, 1, .dynamic_precedence = 1, .production_id = 9), SHIFT(270),
+  [2451] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_with_item, 1, .dynamic_precedence = 1, .production_id = 3), SHIFT(270),
   [2454] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1201),
   [2456] = {.entry = {.count = 1, .reusable = true}}, SHIFT(233),
   [2458] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1252),
@@ -107030,29 +107077,29 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2518] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1804),
   [2520] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1799),
   [2522] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__f_expression, 1),
-  [2524] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 16), SHIFT_REPEAT(302),
-  [2527] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 16), SHIFT_REPEAT(1612),
-  [2530] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 16), SHIFT_REPEAT(1612),
-  [2533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 16),
-  [2535] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23),
-  [2537] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(440),
-  [2540] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda, 3, .production_id = 22),
-  [2542] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(564),
+  [2524] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 15), SHIFT_REPEAT(302),
+  [2527] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 15), SHIFT_REPEAT(1612),
+  [2530] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 15), SHIFT_REPEAT(1612),
+  [2533] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 2, .production_id = 15),
+  [2535] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22),
+  [2537] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(440),
+  [2540] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda, 3, .production_id = 21),
+  [2542] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(564),
   [2545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(558),
   [2547] = {.entry = {.count = 1, .reusable = true}}, SHIFT(557),
-  [2549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_operator, 3, .production_id = 26),
-  [2551] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_as_pattern, 3, .production_id = 27),
+  [2549] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_boolean_operator, 3, .production_id = 25),
+  [2551] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_as_pattern, 3, .production_id = 26),
   [2553] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_not_operator, 2, .production_id = 8),
-  [2555] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean_operator, 3, .production_id = 26),
-  [2557] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(527),
+  [2555] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_boolean_operator, 3, .production_id = 25),
+  [2557] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(527),
   [2560] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_yield, 3),
-  [2562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda, 4, .production_id = 52),
+  [2562] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda, 4, .production_id = 51),
   [2564] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raise_statement, 2),
   [2566] = {.entry = {.count = 1, .reusable = true}}, SHIFT(495),
   [2568] = {.entry = {.count = 1, .reusable = true}}, SHIFT(321),
   [2570] = {.entry = {.count = 1, .reusable = true}}, SHIFT(564),
   [2572] = {.entry = {.count = 1, .reusable = true}}, SHIFT(561),
-  [2574] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_as_pattern, 3, .production_id = 27),
+  [2574] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_as_pattern, 3, .production_id = 26),
   [2576] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_conditional_expression, 5),
   [2578] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_assert_statement_repeat1, 2),
   [2580] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_not_operator, 2, .production_id = 8),
@@ -107075,8 +107122,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(341),
   [2616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1254),
   [2618] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2136),
-  [2620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, .production_id = 53),
-  [2622] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(498),
+  [2620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pair, 3, .production_id = 52),
+  [2622] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(498),
   [2625] = {.entry = {.count = 1, .reusable = true}}, SHIFT(330),
   [2627] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1130),
   [2629] = {.entry = {.count = 1, .reusable = true}}, SHIFT(498),
@@ -107091,7 +107138,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2647] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2219),
   [2649] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2215),
   [2651] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2198),
-  [2653] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(530),
+  [2653] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(530),
   [2656] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_delete_statement, 2),
   [2658] = {.entry = {.count = 1, .reusable = true}}, SHIFT(333),
   [2660] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1286),
@@ -107107,10 +107154,10 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2680] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_expression_statement, 1),
   [2682] = {.entry = {.count = 1, .reusable = true}}, SHIFT(392),
   [2684] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__right_hand_side, 1),
-  [2686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 4, .production_id = 10),
+  [2686] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 4, .production_id = 9),
   [2688] = {.entry = {.count = 1, .reusable = true}}, SHIFT(322),
   [2690] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1334),
-  [2692] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(453),
+  [2692] = {.entry = {.count = 2, .reusable = false}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(453),
   [2695] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_print_statement_repeat1, 2, .production_id = 8),
   [2697] = {.entry = {.count = 1, .reusable = true}}, SHIFT(412),
   [2699] = {.entry = {.count = 1, .reusable = true}}, SHIFT(617),
@@ -107143,20 +107190,20 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2759] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(1578),
   [2762] = {.entry = {.count = 2, .reusable = false}}, REDUCE(aux_sym_string_content_repeat1, 2), SHIFT_REPEAT(1578),
   [2765] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_content_repeat1, 2),
-  [2767] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(468),
+  [2767] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(468),
   [2770] = {.entry = {.count = 1, .reusable = true}}, SHIFT(516),
   [2772] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__comprehension_clauses, 2),
   [2774] = {.entry = {.count = 1, .reusable = true}}, SHIFT(531),
   [2776] = {.entry = {.count = 1, .reusable = true}}, SHIFT(480),
   [2778] = {.entry = {.count = 1, .reusable = true}}, SHIFT(510),
   [2780] = {.entry = {.count = 1, .reusable = true}}, SHIFT(509),
-  [2782] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 23), SHIFT(531),
+  [2782] = {.entry = {.count = 2, .reusable = true}}, REDUCE(sym_named_expression, 3, .production_id = 22), SHIFT(531),
   [2785] = {.entry = {.count = 1, .reusable = true}}, SHIFT(297),
   [2787] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1219),
   [2789] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__comprehension_clauses_repeat1, 2), SHIFT_REPEAT(439),
   [2792] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__comprehension_clauses_repeat1, 2), SHIFT_REPEAT(2220),
   [2795] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__comprehension_clauses_repeat1, 2), SHIFT_REPEAT(816),
-  [2798] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 76),
+  [2798] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 75),
   [2800] = {.entry = {.count = 1, .reusable = true}}, SHIFT(405),
   [2802] = {.entry = {.count = 1, .reusable = true}}, SHIFT(439),
   [2804] = {.entry = {.count = 1, .reusable = true}}, SHIFT(309),
@@ -107182,75 +107229,75 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [2844] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dotted_name, 1),
   [2846] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2101),
   [2848] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2),
-  [2850] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 6, .production_id = 97),
-  [2852] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 6, .production_id = 97),
-  [2854] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_argument, 3, .production_id = 23),
-  [2856] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 31),
-  [2858] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 31),
+  [2850] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 6, .production_id = 96),
+  [2852] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 6, .production_id = 96),
+  [2854] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_argument, 3, .production_id = 22),
+  [2856] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 30),
+  [2858] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 30),
   [2860] = {.entry = {.count = 1, .reusable = true}}, SHIFT(283),
-  [2862] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_parameter, 3, .production_id = 23),
+  [2862] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_default_parameter, 3, .production_id = 22),
   [2864] = {.entry = {.count = 1, .reusable = true}}, SHIFT(288),
-  [2866] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 110),
-  [2868] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raise_statement, 3, .production_id = 20),
-  [2870] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 4, .production_id = 84),
+  [2866] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 6, .production_id = 109),
+  [2868] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raise_statement, 3, .production_id = 19),
+  [2870] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 4, .production_id = 83),
   [2872] = {.entry = {.count = 1, .reusable = true}}, SHIFT(294),
-  [2874] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 21),
+  [2874] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 20),
   [2876] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_for_in_clause_repeat1, 2),
   [2878] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_for_in_clause_repeat1, 2), SHIFT_REPEAT(365),
-  [2881] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 80),
-  [2883] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 80),
+  [2881] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 79),
+  [2883] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 79),
   [2885] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__collection_elements_repeat1, 2),
-  [2887] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 79),
-  [2889] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 79),
-  [2891] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 58),
-  [2893] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 58),
+  [2887] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 78),
+  [2889] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 78),
+  [2891] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 57),
+  [2893] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 57),
   [2895] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_list_splat, 2),
   [2897] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_for_in_clause_repeat1, 2), SHIFT_REPEAT(398),
   [2900] = {.entry = {.count = 1, .reusable = true}}, SHIFT(277),
-  [2902] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 98),
-  [2904] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_item, 1, .dynamic_precedence = 1, .production_id = 9),
-  [2906] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 59),
-  [2908] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 59),
+  [2902] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 97),
+  [2904] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_with_item, 1, .dynamic_precedence = 1, .production_id = 3),
+  [2906] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 4, .production_id = 58),
+  [2908] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 4, .production_id = 58),
   [2910] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dictionary_splat, 2),
   [2912] = {.entry = {.count = 1, .reusable = true}}, SHIFT(278),
-  [2914] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 99),
+  [2914] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_for_in_clause, 5, .production_id = 98),
   [2916] = {.entry = {.count = 1, .reusable = true}}, SHIFT(282),
-  [2918] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typed_default_parameter, 5, .production_id = 96),
+  [2918] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typed_default_parameter, 5, .production_id = 95),
   [2920] = {.entry = {.count = 1, .reusable = true}}, SHIFT(284),
   [2922] = {.entry = {.count = 1, .reusable = true}}, SHIFT(276),
   [2924] = {.entry = {.count = 1, .reusable = true}}, SHIFT(292),
-  [2926] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_argument, 3, .production_id = 75),
+  [2926] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_keyword_argument, 3, .production_id = 74),
   [2928] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 1, .production_id = 4),
   [2930] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 1, .production_id = 4),
   [2932] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_slice, 5),
   [2934] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_string_repeat1, 1, .production_id = 3),
   [2936] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_string_repeat1, 1, .production_id = 3),
-  [2938] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 81),
-  [2940] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 81),
+  [2938] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 5, .production_id = 80),
+  [2940] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 5, .production_id = 80),
   [2942] = {.entry = {.count = 1, .reusable = true}}, SHIFT(280),
   [2944] = {.entry = {.count = 1, .reusable = true}}, SHIFT(291),
   [2946] = {.entry = {.count = 1, .reusable = true}}, SHIFT(551),
   [2948] = {.entry = {.count = 1, .reusable = true}}, SHIFT(563),
   [2950] = {.entry = {.count = 1, .reusable = true}}, SHIFT(83),
-  [2952] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raise_statement, 4, .production_id = 41),
+  [2952] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_raise_statement, 4, .production_id = 40),
   [2954] = {.entry = {.count = 1, .reusable = true}}, SHIFT(285),
   [2956] = {.entry = {.count = 1, .reusable = true}}, SHIFT(477),
   [2958] = {.entry = {.count = 1, .reusable = true}}, SHIFT(562),
   [2960] = {.entry = {.count = 1, .reusable = true}}, SHIFT(138),
   [2962] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_dotted_name, 2),
   [2964] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_assert_statement_repeat1, 2), SHIFT_REPEAT(559),
-  [2967] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 3, .production_id = 31),
-  [2969] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 3, .production_id = 31),
+  [2967] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_interpolation, 3, .production_id = 30),
+  [2969] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_interpolation, 3, .production_id = 30),
   [2971] = {.entry = {.count = 1, .reusable = true}}, SHIFT(279),
   [2973] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_decorated_definition_repeat1, 2),
   [2975] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_decorated_definition_repeat1, 2), SHIFT_REPEAT(474),
   [2978] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_dotted_name_repeat1, 2),
   [2980] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_dotted_name_repeat1, 2), SHIFT_REPEAT(2101),
   [2983] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_for_in_clause_repeat1, 2), SHIFT_REPEAT(387),
-  [2986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 101),
+  [2986] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 100),
   [2988] = {.entry = {.count = 1, .reusable = true}}, SHIFT(101),
   [2990] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_assert_statement_repeat1, 2), SHIFT_REPEAT(500),
-  [2993] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda_within_for_in_clause, 3, .production_id = 22),
+  [2993] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda_within_for_in_clause, 3, .production_id = 21),
   [2995] = {.entry = {.count = 1, .reusable = true}}, SHIFT(446),
   [2997] = {.entry = {.count = 1, .reusable = true}}, SHIFT(554),
   [2999] = {.entry = {.count = 1, .reusable = true}}, SHIFT(287),
@@ -107274,7 +107321,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3036] = {.entry = {.count = 1, .reusable = true}}, SHIFT(128),
   [3038] = {.entry = {.count = 1, .reusable = true}}, SHIFT(293),
   [3040] = {.entry = {.count = 1, .reusable = true}}, SHIFT(129),
-  [3042] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 3, .production_id = 17),
+  [3042] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 3, .production_id = 16),
   [3044] = {.entry = {.count = 1, .reusable = true}}, SHIFT(343),
   [3046] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1699),
   [3048] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1754),
@@ -107285,7 +107332,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3058] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 1, .production_id = 6),
   [3060] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1713),
   [3062] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2104),
-  [3064] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda_within_for_in_clause, 4, .production_id = 52),
+  [3064] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_lambda_within_for_in_clause, 4, .production_id = 51),
   [3066] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 2, .production_id = 6),
   [3068] = {.entry = {.count = 1, .reusable = true}}, SHIFT(97),
   [3070] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1750),
@@ -107307,15 +107354,15 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3104] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_decorator, 3),
   [3106] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_nonlocal_statement, 2),
   [3108] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2213),
-  [3110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_print_statement_repeat1, 2, .production_id = 40),
-  [3112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_print_statement_repeat1, 2, .production_id = 40), SHIFT_REPEAT(458),
-  [3115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 103), SHIFT_REPEAT(353),
-  [3118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 103),
+  [3110] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_print_statement_repeat1, 2, .production_id = 39),
+  [3112] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_print_statement_repeat1, 2, .production_id = 39), SHIFT_REPEAT(458),
+  [3115] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 102), SHIFT_REPEAT(353),
+  [3118] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_case_clause_repeat1, 2, .production_id = 102),
   [3120] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1695),
   [3122] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 2),
   [3124] = {.entry = {.count = 1, .reusable = true}}, SHIFT(403),
   [3126] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_global_statement, 2),
-  [3128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 5, .production_id = 10),
+  [3128] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 5, .production_id = 9),
   [3130] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_import_prefix, 1),
   [3132] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1756),
   [3134] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1771),
@@ -107330,17 +107377,17 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3153] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_nonlocal_statement, 3),
   [3155] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_global_statement, 3),
   [3157] = {.entry = {.count = 1, .reusable = true}}, SHIFT(379),
-  [3159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 2, .production_id = 17),
+  [3159] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym__import_list, 2, .production_id = 16),
   [3161] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1718),
   [3163] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1706),
-  [3165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 33),
-  [3167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 33), SHIFT_REPEAT(1801),
+  [3165] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 32),
+  [3167] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 32), SHIFT_REPEAT(1801),
   [3170] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assert_statement, 3),
-  [3172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 3, .production_id = 19),
+  [3172] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 3, .production_id = 18),
   [3174] = {.entry = {.count = 1, .reusable = true}}, SHIFT(358),
-  [3176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 3, .production_id = 18),
+  [3176] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_print_statement, 3, .production_id = 17),
   [3178] = {.entry = {.count = 1, .reusable = true}}, SHIFT(356),
-  [3180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 32),
+  [3180] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 31),
   [3182] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_global_statement_repeat1, 2),
   [3184] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_global_statement_repeat1, 2), SHIFT_REPEAT(2213),
   [3187] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1886),
@@ -107362,7 +107409,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3220] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_assert_statement_repeat1, 2), SHIFT_REPEAT(493),
   [3223] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__parameters_repeat1, 2), SHIFT_REPEAT(1406),
   [3226] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__parameters_repeat1, 2),
-  [3228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typed_parameter, 3, .production_id = 51),
+  [3228] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_typed_parameter, 3, .production_id = 50),
   [3230] = {.entry = {.count = 1, .reusable = true}}, SHIFT(501),
   [3232] = {.entry = {.count = 1, .reusable = true}}, SHIFT(215),
   [3234] = {.entry = {.count = 1, .reusable = true}}, SHIFT(386),
@@ -107373,15 +107420,15 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3244] = {.entry = {.count = 1, .reusable = true}}, SHIFT(407),
   [3246] = {.entry = {.count = 1, .reusable = true}}, SHIFT(334),
   [3248] = {.entry = {.count = 1, .reusable = true}}, SHIFT(409),
-  [3250] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_format_specifier_repeat1, 1, .production_id = 57),
-  [3252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_format_specifier_repeat1, 1, .production_id = 57),
+  [3250] = {.entry = {.count = 1, .reusable = false}}, REDUCE(aux_sym_format_specifier_repeat1, 1, .production_id = 56),
+  [3252] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_format_specifier_repeat1, 1, .production_id = 56),
   [3254] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_assert_statement_repeat1, 2), SHIFT_REPEAT(438),
   [3257] = {.entry = {.count = 1, .reusable = true}}, SHIFT(148),
   [3259] = {.entry = {.count = 1, .reusable = true}}, SHIFT(586),
   [3261] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__simple_statements_repeat1, 2), SHIFT_REPEAT(160),
   [3264] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym__simple_statements_repeat1, 2),
   [3266] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1636),
-  [3268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 24),
+  [3268] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 23),
   [3270] = {.entry = {.count = 1, .reusable = true}}, SHIFT(182),
   [3272] = {.entry = {.count = 1, .reusable = true}}, SHIFT(384),
   [3274] = {.entry = {.count = 1, .reusable = true}}, SHIFT(814),
@@ -107410,8 +107457,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3324] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1194),
   [3326] = {.entry = {.count = 1, .reusable = true}}, SHIFT(225),
   [3328] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1404),
-  [3330] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 46), SHIFT_REPEAT(471),
-  [3333] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 46),
+  [3330] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 45), SHIFT_REPEAT(471),
+  [3333] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_match_statement_repeat1, 2, .production_id = 45),
   [3335] = {.entry = {.count = 1, .reusable = false}}, REDUCE(sym_relative_import, 1),
   [3337] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1082),
   [3339] = {.entry = {.count = 1, .reusable = true}}, SHIFT(235),
@@ -107427,8 +107474,8 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3359] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1319),
   [3361] = {.entry = {.count = 1, .reusable = true}}, SHIFT(327),
   [3363] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1320),
-  [3365] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 78), SHIFT_REPEAT(385),
-  [3368] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 78),
+  [3365] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 77), SHIFT_REPEAT(385),
+  [3368] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_subscript_repeat1, 2, .production_id = 77),
   [3370] = {.entry = {.count = 1, .reusable = true}}, SHIFT(219),
   [3372] = {.entry = {.count = 1, .reusable = true}}, SHIFT(220),
   [3374] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1880),
@@ -107472,7 +107519,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3453] = {.entry = {.count = 1, .reusable = true}}, SHIFT(346),
   [3455] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1265),
   [3457] = {.entry = {.count = 1, .reusable = true}}, SHIFT(444),
-  [3459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_aliased_import, 3, .production_id = 34),
+  [3459] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_aliased_import, 3, .production_id = 33),
   [3461] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym_with_clause_repeat1, 2), SHIFT_REPEAT(431),
   [3464] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1295),
   [3466] = {.entry = {.count = 1, .reusable = true}}, SHIFT(237),
@@ -107488,7 +107535,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3487] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1970),
   [3489] = {.entry = {.count = 1, .reusable = true}}, SHIFT(157),
   [3491] = {.entry = {.count = 1, .reusable = true}}, SHIFT(2027),
-  [3493] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 33), SHIFT_REPEAT(1881),
+  [3493] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__import_list_repeat1, 2, .production_id = 32), SHIFT_REPEAT(1881),
   [3496] = {.entry = {.count = 1, .reusable = true}}, SHIFT(146),
   [3498] = {.entry = {.count = 1, .reusable = true}}, SHIFT(625),
   [3500] = {.entry = {.count = 1, .reusable = true}}, SHIFT(369),
@@ -107511,7 +107558,7 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3534] = {.entry = {.count = 1, .reusable = true}}, SHIFT(263),
   [3536] = {.entry = {.count = 1, .reusable = true}}, SHIFT(158),
   [3538] = {.entry = {.count = 2, .reusable = true}}, REDUCE(aux_sym__collection_elements_repeat1, 2), SHIFT_REPEAT(290),
-  [3541] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 2, .production_id = 10),
+  [3541] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_exec_statement, 2, .production_id = 9),
   [3543] = {.entry = {.count = 1, .reusable = true}}, SHIFT(475),
   [3545] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1401),
   [3547] = {.entry = {.count = 1, .reusable = true}}, SHIFT(262),
@@ -107532,30 +107579,30 @@ static const TSParseActionEntry ts_parse_actions[] = {
   [3578] = {.entry = {.count = 1, .reusable = true}}, SHIFT(433),
   [3580] = {.entry = {.count = 1, .reusable = true}}, SHIFT(144),
   [3582] = {.entry = {.count = 1, .reusable = true}}, SHIFT(420),
-  [3584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_list_splat, 3, .production_id = 38),
+  [3584] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_list_splat, 3, .production_id = 37),
   [3586] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_pass_statement, 1),
   [3588] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_break_statement, 1),
   [3590] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_continue_statement, 1),
   [3592] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parenthesized_list_splat, 3),
   [3594] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1399),
   [3596] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 2),
-  [3598] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 25),
+  [3598] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 3, .production_id = 24),
   [3600] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_positional_separator, 1),
-  [3602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 4, .production_id = 37),
-  [3604] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_augmented_assignment, 3, .production_id = 26),
+  [3602] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 4, .production_id = 36),
+  [3604] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_augmented_assignment, 3, .production_id = 25),
   [3606] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_parameters, 3),
   [3608] = {.entry = {.count = 1, .reusable = true}}, SHIFT(91),
   [3610] = {.entry = {.count = 1, .reusable = true}}, SHIFT(418),
-  [3612] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 4, .production_id = 36),
+  [3612] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 4, .production_id = 35),
   [3614] = {.entry = {.count = 1, .reusable = true}}, SHIFT(88),
   [3616] = {.entry = {.count = 1, .reusable = true}}, SHIFT(435),
-  [3618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 5, .production_id = 74),
-  [3620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, .production_id = 38),
+  [3618] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_assignment, 5, .production_id = 73),
+  [3620] = {.entry = {.count = 1, .reusable = true}}, REDUCE(aux_sym_argument_list_repeat1, 2, .production_id = 37),
   [3622] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_statement, 2, .production_id = 5),
-  [3624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 6, .production_id = 83),
+  [3624] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_import_from_statement, 6, .production_id = 82),
   [3626] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_wildcard_import, 1),
-  [3628] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_future_import_statement, 4, .production_id = 35),
-  [3630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_future_import_statement, 6, .production_id = 82),
+  [3628] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_future_import_statement, 4, .production_id = 34),
+  [3630] = {.entry = {.count = 1, .reusable = true}}, REDUCE(sym_future_import_statement, 6, .production_id = 81),
   [3632] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1210),
   [3634] = {.entry = {.count = 1, .reusable = true}}, SHIFT(1922),
   [3636] = {.entry = {.count = 1, .reusable = true}}, SHIFT(547),

--- a/test/corpus/statements.txt
+++ b/test/corpus/statements.txt
@@ -161,8 +161,10 @@ print >> a, "b", "c"
   (print_statement
     (chevron
       (identifier))
-    (string (string_content))
-    (string (string_content))))
+    (string
+      (string_content))
+    (string
+      (string_content))))
 
 ================================================================================
 Assert statements
@@ -606,7 +608,8 @@ with e as f, g as h,:
           (call
             (identifier)
             (argument_list
-              (string (string_content))))
+              (string
+                (string_content))))
           (as_pattern_target
             (identifier))))
       (with_item
@@ -614,7 +617,8 @@ with e as f, g as h,:
           (call
             (identifier)
             (argument_list
-              (string (string_content))))
+              (string
+                (string_content))))
           (as_pattern_target
             (identifier)))))
     (block
@@ -760,7 +764,8 @@ async def d(a:str="default", b=c) -> None:
         name: (identifier)
         type: (type
           (identifier))
-        value: (string string_content: (string_content)))
+        value: (string
+          value: (string_content)))
       (default_parameter
         name: (identifier)
         value: (identifier)))
@@ -1080,7 +1085,6 @@ def spam():
         (expression_statement
           (ellipsis))))))
 
-
 ================================================================================
 Raise statements
 ================================================================================
@@ -1097,12 +1101,14 @@ raise RunTimeError('NO') from e
     (call
       (identifier)
       (argument_list
-        (string (string_content)))))
+        (string
+          (string_content)))))
   (raise_statement
     (call
       (identifier)
       (argument_list
-        (string (string_content))))
+        (string
+          (string_content))))
     (identifier)))
 
 ================================================================================
@@ -1220,7 +1226,8 @@ print "a"
 
 (module
   (print_statement
-    (string (string_content)))
+    (string
+      (string_content)))
   (comment))
 
 ================================================================================
@@ -1251,12 +1258,15 @@ exec 'x+=1' in a, b
 
 (module
   (exec_statement
-    (string (string_content)))
+    (string
+      (string_content)))
   (exec_statement
-    (string (string_content))
+    (string
+      (string_content))
     (none))
   (exec_statement
-    (string (string_content))
+    (string
+      (string_content))
     (identifier)
     (identifier)))
 
@@ -1323,11 +1333,13 @@ or len("aa")
       (call
         (identifier)
         (argument_list
-          (string (string_content))))
+          (string
+            (string_content))))
       (call
         (identifier)
         (argument_list
-          (string (string_content)))))))
+          (string
+            (string_content)))))))
 
 ================================================================================
 Statements with semicolons


### PR DESCRIPTION
Fields in tree-sitter exist for fast nodes addressing and not for the nodes naming purpose. It doesn't have a lot of sense to name `string_content` field exactly as a node's `kind()` because nodes kind is enough.
Also string quotes aren't  prefix and suffix of a string itself and it would be better to use something custom like `open` / `close`.