### PR TITLE
WASM Compatible Rust Bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ node_modules
 build
 *.log
 /examples/*/
-/target/
+**/target/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,14 @@ include = [
 path = "bindings/rust/lib.rs"
 
 [dependencies]
-tree-sitter = ">= 0.19, < 0.21"
+tree-sitter = { version = ">= 0.19, < 0.21", optional = true }
+tree-sitter-c2rust = { version = ">= 0.19, < 0.21", optional = true }
+bytemuck = { version = "1.13", features = ["derive"] }
 
 [build-dependencies]
 cc = "1.0"
+
+[features]
+default = ["native"]
+native = ["dep:tree-sitter"]
+wasm = ["dep:tree-sitter-c2rust"]

--- a/bindings/rust/build.rs
+++ b/bindings/rust/build.rs
@@ -3,26 +3,24 @@ extern crate cc;
 
 fn main() {
     let src_dir = Path::new("src");
+    let parser_path = src_dir.join("parser.c");
+    let mut compiler = cc::Build::new();
 
-    let mut c_config = cc::Build::new();
-    c_config.include(&src_dir);
-    c_config
+    // set minimal C sysroot if wasm32-unknown-unknown
+    if std::env::var("TARGET").unwrap() == "wasm32-unknown-unknown" {
+        let sysroot_dir = Path::new("bindings/rust/wasm-sysroot");
+        compiler
+            .archiver("llvm-ar")
+            .include(&sysroot_dir);
+    }
+
+    compiler
+        .include(&src_dir)
         .flag_if_supported("-Wno-unused-parameter")
         .flag_if_supported("-Wno-unused-but-set-variable")
-        .flag_if_supported("-Wno-trigraphs");
-    let parser_path = src_dir.join("parser.c");
-    c_config.file(&parser_path);
-    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
-    c_config.compile("parser");
+        .flag_if_supported("-Wno-trigraphs")
+        .file(&parser_path)
+        .compile("parser");
 
-    let mut cpp_config = cc::Build::new();
-    cpp_config.cpp(true);
-    cpp_config.include(&src_dir);
-    cpp_config
-        .flag_if_supported("-Wno-unused-parameter")
-        .flag_if_supported("-Wno-unused-but-set-variable");
-    let scanner_path = src_dir.join("scanner.cc");
-    cpp_config.file(&scanner_path);
-    println!("cargo:rerun-if-changed={}", scanner_path.to_str().unwrap());
-    cpp_config.compile("scanner");
+    println!("cargo:rerun-if-changed={}", parser_path.to_str().unwrap());
 }

--- a/bindings/rust/lib.rs
+++ b/bindings/rust/lib.rs
@@ -29,7 +29,16 @@
 //! [Parser]: https://docs.rs/tree-sitter/*/tree_sitter/struct.Parser.html
 //! [tree-sitter]: https://tree-sitter.github.io/
 
+#[cfg(all(feature = "native", feature = "wasm"))]
+compile_error!("feature \"native\" and feature \"wasm\" cannot be enabled at the same time");
+
+#[cfg(feature = "native")]
 use tree_sitter::Language;
+
+#[cfg(feature = "wasm")]
+use tree_sitter_c2rust::Language;
+
+mod scanner;
 
 extern "C" {
     fn tree_sitter_python() -> Language;
@@ -58,9 +67,15 @@ pub const TAGGING_QUERY: &'static str = include_str!("../../queries/tags.scm");
 
 #[cfg(test)]
 mod tests {
+    #[cfg(feature = "native")]
+    use tree_sitter::Parser;
+
+    #[cfg(feature = "wasm")]
+    use tree_sitter_c2rust::Parser;
+
     #[test]
     fn can_load_grammar() {
-        let mut parser = tree_sitter::Parser::new();
+        let mut parser = Parser::new();
         parser
             .set_language(super::language())
             .expect("Error loading Python grammar");

--- a/bindings/rust/scanner.rs
+++ b/bindings/rust/scanner.rs
@@ -1,0 +1,502 @@
+use bytemuck::{cast_slice, AnyBitPattern, NoUninit};
+use std::boxed::Box;
+use std::cmp::min;
+use std::os::raw::{c_char, c_uint, c_void};
+
+#[derive(Copy, Clone)]
+#[repr(C)]
+pub struct TSLexer {
+    pub lookahead: i32,
+    pub result_symbol: u16,
+    pub advance: Option<unsafe extern "C" fn(*mut TSLexer, bool) -> ()>,
+    pub mark_end: Option<unsafe extern "C" fn(*mut TSLexer) -> ()>,
+    pub get_column: Option<unsafe extern "C" fn(*mut TSLexer) -> i32>,
+    pub is_at_included_range_start: Option<unsafe extern "C" fn(*const TSLexer) -> bool>,
+    pub eof: Option<unsafe extern "C" fn(*const TSLexer) -> bool>,
+}
+
+#[repr(C)]
+struct ValidSymbols {
+    newline: bool,
+    indent: bool,
+    dedent: bool,
+    string_start: bool,
+    string_content: bool,
+    string_end: bool,
+    comment: bool,
+    close_paren: bool,
+    close_bracket: bool,
+    close_brace: bool,
+}
+
+#[allow(dead_code)]
+mod symbol_values {
+    pub const NEWLINE: u16 = 0;
+    pub const INDENT: u16 = 1;
+    pub const DEDENT: u16 = 2;
+    pub const STRING_START: u16 = 3;
+    pub const STRING_CONTENT: u16 = 4;
+    pub const STRING_END: u16 = 5;
+    pub const COMMENT: u16 = 6;
+    pub const CLOSE_PAREN: u16 = 7;
+    pub const CLOSE_BRACKET: u16 = 8;
+    pub const CLOSE_BRACE: u16 = 9;
+}
+
+#[derive(Clone, Copy, NoUninit, AnyBitPattern)]
+#[repr(transparent)]
+struct Delimiter {
+    flags: u8,
+}
+
+impl Delimiter {
+    const SINGLE_QUOTE: u8 = 1 << 0;
+    const DOUBLE_QUOTE: u8 = 1 << 1;
+    const BACK_QUOTE: u8 = 1 << 2;
+    const RAW: u8 = 1 << 3;
+    const FORMAT: u8 = 1 << 4;
+    const TRIPLE: u8 = 1 << 5;
+    const BYTES: u8 = 1 << 6;
+
+    fn new() -> Self {
+        Delimiter { flags: 0 }
+    }
+
+    fn is_format(&self) -> bool {
+        self.flags & Delimiter::FORMAT != 0
+    }
+
+    fn is_raw(&self) -> bool {
+        self.flags & Delimiter::RAW != 0
+    }
+
+    fn is_triple(&self) -> bool {
+        self.flags & Delimiter::TRIPLE != 0
+    }
+
+    fn is_bytes(&self) -> bool {
+        self.flags & Delimiter::BYTES != 0
+    }
+
+    fn end_character(&self) -> i32 {
+        if self.flags & Delimiter::SINGLE_QUOTE != 0 {
+            '\'' as i32
+        } else if self.flags & Delimiter::DOUBLE_QUOTE != 0 {
+            '"' as i32
+        } else if self.flags & Delimiter::BACK_QUOTE != 0 {
+            '`' as i32
+        } else {
+            0
+        }
+    }
+
+    fn set_format(&mut self) {
+        self.flags |= Delimiter::FORMAT;
+    }
+
+    fn set_raw(&mut self) {
+        self.flags |= Delimiter::RAW;
+    }
+
+    fn set_triple(&mut self) {
+        self.flags |= Delimiter::TRIPLE;
+    }
+
+    fn set_bytes(&mut self) {
+        self.flags |= Delimiter::BYTES;
+    }
+
+    fn set_end_character(&mut self, character: char) {
+        match character {
+            '\'' => self.flags |= Delimiter::SINGLE_QUOTE,
+            '"' => self.flags |= Delimiter::DOUBLE_QUOTE,
+            '`' => self.flags |= Delimiter::BACK_QUOTE,
+            _ => panic!("Invalid end character"),
+        }
+    }
+}
+
+const BUFFER_SIZE: usize = 1024;
+struct Scanner {
+    // this is stored as u16 in orig but serialized as u8 we so might as well use u8 all the time
+    indent_length_stack: Vec<u8>,
+
+    // stored as another vector of u8
+    delimiter_stack: Vec<Delimiter>,
+}
+
+impl Scanner {
+    fn new() -> Self {
+        Scanner {
+            indent_length_stack: vec![0],
+            delimiter_stack: Vec::new(),
+        }
+    }
+
+    fn serialize(&mut self, buffer: &mut [u8]) -> usize {
+        let mut i = 0;
+
+        // prevent overflow (because we only have 1 byte to store the delimiter count)
+        let delimiter_count = min(self.delimiter_stack.len(), u8::MAX as usize);
+
+        // first bit is the number of delimiters in the stack
+        buffer[i] = delimiter_count as u8;
+        i += 1;
+
+        // copy delimiters into buffer
+        if delimiter_count > 0 {
+            buffer[i..(i + delimiter_count)]
+                .copy_from_slice(cast_slice(self.delimiter_stack.as_slice()));
+            i += delimiter_count;
+        }
+
+        // copy indent lengths into buffer (do not overflow buffer)
+        let remaining_space = BUFFER_SIZE - i;
+        let indents_to_copy = min(self.indent_length_stack.len() - 1, remaining_space);
+
+        if indents_to_copy > 0 {
+            buffer[i..(i + indents_to_copy)].copy_from_slice(
+                // skip the first index, which is always 0
+                &self.indent_length_stack[1..(1 + indents_to_copy)],
+            );
+            i += indents_to_copy;
+        }
+
+        // return the number of bytes written
+        i
+    }
+
+    fn deserialize(&mut self, buffer: &[u8], length: usize) {
+        // clear existing stacks
+        self.delimiter_stack.clear();
+        self.indent_length_stack.clear();
+
+        // always start with index 0
+        self.indent_length_stack.push(0);
+
+        // return if nothing to deserialize
+        if length == 0 {
+            return;
+        }
+
+        let mut i = 0;
+
+        // the first byte of the buffer is the number of delimiters
+        let delimiter_count = buffer[i];
+        i += 1;
+
+        // the next delimiter_count bytes are the delimiters
+        self.delimiter_stack
+            .extend_from_slice(cast_slice(&buffer[i..(i + delimiter_count as usize)]));
+        i += delimiter_count as usize;
+
+        // the remaining bytes are the indent lengths
+        self.indent_length_stack
+            .extend_from_slice(&buffer[i..length]);
+    }
+
+    fn scan(&mut self, lexer: &mut TSLexer, valid_symbols: &ValidSymbols) -> bool {
+        use symbol_values::*;
+
+        let error_recovery_mode = valid_symbols.string_content && valid_symbols.indent;
+        let within_brackets =
+            valid_symbols.close_brace || valid_symbols.close_paren || valid_symbols.close_bracket;
+
+        if valid_symbols.string_content && !self.delimiter_stack.is_empty() && !error_recovery_mode
+        {
+            let delimiter = self.delimiter_stack.last().unwrap();
+            let end_character = delimiter.end_character();
+            let mut has_content = false;
+
+            while lexer.lookahead != 0 {
+                if (lexer.lookahead == '{' as i32 || lexer.lookahead == '}' as i32)
+                    && delimiter.is_format()
+                {
+                    mark_end(lexer);
+                    lexer.result_symbol = STRING_CONTENT;
+                    return has_content;
+                } else if lexer.lookahead == '\\' as i32 {
+                    if delimiter.is_raw() {
+                        // Step over the backslash.
+                        advance(lexer);
+                        // Step over any escaped quotes.
+                        if lexer.lookahead == delimiter.end_character()
+                            || lexer.lookahead == '\\' as i32
+                        {
+                            advance(lexer);
+                        }
+                        continue;
+                    } else if delimiter.is_bytes() {
+                        mark_end(lexer);
+                        advance(lexer);
+                        if lexer.lookahead == 'N' as i32
+                            || lexer.lookahead == 'u' as i32
+                            || lexer.lookahead == 'U' as i32
+                        {
+                            // In bytes string, \N{...}, \uXXXX and \UXXXXXXXX are not escape sequences
+                            // https://docs.python.org/3/reference/lexical_analysis.html#string-and-bytes-literals
+                            advance(lexer);
+                        } else {
+                            lexer.result_symbol = STRING_CONTENT;
+                            return has_content;
+                        }
+                    } else {
+                        mark_end(lexer);
+                        lexer.result_symbol = STRING_CONTENT;
+                        return has_content;
+                    }
+                } else if lexer.lookahead == end_character {
+                    if delimiter.is_triple() {
+                        mark_end(lexer);
+                        advance(lexer);
+                        if lexer.lookahead == end_character {
+                            advance(lexer);
+                            if lexer.lookahead == end_character {
+                                if has_content {
+                                    lexer.result_symbol = STRING_CONTENT;
+                                } else {
+                                    advance(lexer);
+                                    mark_end(lexer);
+                                    self.delimiter_stack.pop();
+                                    lexer.result_symbol = STRING_END;
+                                }
+                                return true;
+                            } else {
+                                mark_end(lexer);
+                                lexer.result_symbol = STRING_CONTENT;
+                                return true;
+                            }
+                        } else {
+                            mark_end(lexer);
+                            lexer.result_symbol = STRING_CONTENT;
+                            return true;
+                        }
+                    } else {
+                        if has_content {
+                            lexer.result_symbol = STRING_CONTENT;
+                        } else {
+                            advance(lexer);
+                            self.delimiter_stack.pop();
+                            lexer.result_symbol = STRING_END;
+                        }
+                        mark_end(lexer);
+                        return true;
+                    }
+                } else if lexer.lookahead == '\n' as i32 && has_content && !delimiter.is_triple() {
+                    return false;
+                }
+                advance(lexer);
+                has_content = true;
+            }
+        }
+
+        mark_end(lexer);
+
+        // find the end of the line.
+        // identify indentation level and first comment along the way
+        let mut found_end_of_line = false;
+        let mut indent_length: u8 = 0;
+        let mut first_comment_indent_length: Option<u8> = None;
+        loop {
+            match std::char::from_u32(lexer.lookahead as u32).unwrap() {
+                '\n' => {
+                    found_end_of_line = true;
+                    indent_length = 0;
+                    skip(lexer);
+                }
+                ' ' => {
+                    indent_length += 1;
+                    skip(lexer);
+                }
+                '\r' => {
+                    indent_length = 0;
+                    skip(lexer);
+                }
+                '\t' => {
+                    indent_length += 8;
+                    skip(lexer);
+                }
+                '#' => {
+                    if first_comment_indent_length.is_none() {
+                        first_comment_indent_length = Some(indent_length);
+                    }
+                    while lexer.lookahead != 0 && lexer.lookahead != '\n' as i32 {
+                        skip(lexer);
+                    }
+                    skip(lexer);
+                    indent_length = 0;
+                }
+                '\\' => {
+                    skip(lexer);
+                    if lexer.lookahead == '\r' as i32 {
+                        skip(lexer);
+                    }
+                    if lexer.lookahead == '\n' as i32 {
+                        skip(lexer);
+                    } else {
+                        return false;
+                    }
+                }
+                '\x0c' => {
+                    indent_length = 0;
+                    skip(lexer);
+                }
+                '\0' => {
+                    indent_length = 0;
+                    found_end_of_line = true;
+                    break;
+                }
+                _ => break,
+            }
+        }
+
+        if found_end_of_line {
+            if !self.indent_length_stack.is_empty() {
+                let current_indent_length = *self.indent_length_stack.last().unwrap(); // will always have a 0 element at the start
+
+                if valid_symbols.indent && indent_length > current_indent_length {
+                    self.indent_length_stack.push(indent_length);
+                    lexer.result_symbol = INDENT;
+                    return true;
+                }
+
+                if (valid_symbols.dedent || !valid_symbols.newline && !within_brackets)
+                    && indent_length < current_indent_length
+                    // Wait to create a dedent token until we've consumed any comments
+                    // whose indentation matches the current block.
+                    && (first_comment_indent_length.is_none()
+                        || first_comment_indent_length.unwrap() < current_indent_length)
+                {
+                    self.indent_length_stack.pop();
+                    lexer.result_symbol = DEDENT;
+                    return true;
+                }
+            }
+
+            if valid_symbols.newline && !error_recovery_mode {
+                lexer.result_symbol = NEWLINE;
+                return true;
+            }
+        }
+
+        if first_comment_indent_length.is_none() && valid_symbols.string_start {
+            let mut delimiter = Delimiter::new();
+
+            let mut has_flags = false;
+            loop {
+                match std::char::from_u32(lexer.lookahead as u32).unwrap() {
+                    'f' | 'F' => delimiter.set_format(),
+                    'r' | 'R' => delimiter.set_raw(),
+                    'b' | 'B' => delimiter.set_bytes(),
+                    'u' | 'U' => {}
+                    _ => break,
+                }
+
+                has_flags = true;
+                advance(lexer);
+            }
+
+            if lexer.lookahead == '`' as i32 {
+                delimiter.set_end_character('`');
+                advance(lexer);
+                mark_end(lexer);
+            } else if lexer.lookahead == '\'' as i32 {
+                delimiter.set_end_character('\'');
+                advance(lexer);
+                mark_end(lexer);
+                if lexer.lookahead == '\'' as i32 {
+                    advance(lexer);
+                    if lexer.lookahead == '\'' as i32 {
+                        advance(lexer);
+                        mark_end(lexer);
+                        delimiter.set_triple();
+                    }
+                }
+            } else if lexer.lookahead == '"' as i32 {
+                delimiter.set_end_character('"');
+                advance(lexer);
+                mark_end(lexer);
+                if lexer.lookahead == '"' as i32 {
+                    advance(lexer);
+                    if lexer.lookahead == '"' as i32 {
+                        advance(lexer);
+                        mark_end(lexer);
+                        delimiter.set_triple();
+                    }
+                }
+            }
+
+            if delimiter.end_character() != 0 {
+                self.delimiter_stack.push(delimiter);
+                lexer.result_symbol = STRING_START;
+                return true;
+            } else if has_flags {
+                return false;
+            }
+        }
+
+        return false;
+    }
+}
+
+fn advance(lexer: &mut TSLexer) {
+    unsafe {
+        lexer.advance.unwrap()(lexer, false);
+    }
+}
+
+fn skip(lexer: &mut TSLexer) {
+    unsafe {
+        lexer.advance.unwrap()(lexer, true);
+    }
+}
+
+fn mark_end(lexer: &mut TSLexer) {
+    unsafe {
+        lexer.mark_end.unwrap()(lexer);
+    }
+}
+
+/* ======== Interface ======== */
+#[no_mangle]
+pub unsafe extern "C" fn tree_sitter_python_external_scanner_create() -> *mut c_void {
+    let scanner = Box::new(Scanner::new());
+    Box::into_raw(scanner) as *mut c_void
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tree_sitter_python_external_scanner_destroy(payload: *mut c_void) {
+    unsafe { Box::from_raw(payload as *mut Scanner) };
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tree_sitter_python_external_scanner_scan(
+    payload: *mut c_void,
+    lexer: *mut TSLexer,
+    valid_symbols: *const bool,
+) -> bool {
+    let scanner = payload as *mut Scanner;
+    let valid_symbols = valid_symbols as *const ValidSymbols;
+    (*scanner).scan(&mut *lexer, &*valid_symbols)
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tree_sitter_python_external_scanner_serialize(
+    payload: *mut c_void,
+    buffer: *mut c_char,
+) -> c_uint {
+    let scanner = payload as *mut Scanner;
+    let buffer = std::slice::from_raw_parts_mut(buffer as *mut u8, BUFFER_SIZE);
+    (*scanner).serialize(buffer) as c_uint
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn tree_sitter_python_external_scanner_deserialize(
+    payload: *mut c_void,
+    buffer: *const c_char,
+    length: c_uint,
+) {
+    let scanner = payload as *mut Scanner;
+    let buffer = std::slice::from_raw_parts_mut(buffer as *mut u8, BUFFER_SIZE);
+    (*scanner).deserialize(buffer, length as usize);
+}

--- a/bindings/rust/wasm-sysroot/stdint.h
+++ b/bindings/rust/wasm-sysroot/stdint.h
@@ -1,0 +1,9 @@
+typedef signed char int8_t;
+typedef short int16_t;
+typedef long int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned long uint32_t;
+typedef unsigned long long uint64_t;

--- a/bindings/rust/wasm-sysroot/stdlib.h
+++ b/bindings/rust/wasm-sysroot/stdlib.h
@@ -1,0 +1,1 @@
+#define NULL ((void*)0)

--- a/rust-tester/Cargo.toml
+++ b/rust-tester/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tree-sitter-python-tests"
+version = "0.20.2"
+edition = "2021"
+
+[dependencies]
+tree-sitter = ">= 0.19, < 0.21"
+tree-sitter-python = { path = "../" }
+
+ansi_term = "0.12.1"
+anyhow = "1.0.69"
+difference = "2.0.0"
+lazy_static = "1.4.0"
+regex = "1.7.1"
+
+[profile.release-with-debug]
+inherits = "release"
+debug = true

--- a/rust-tester/README.md
+++ b/rust-tester/README.md
@@ -1,0 +1,7 @@
+# Python Rust Tester
+
+A tester to run the corpus tests against the rust scanner (because it's only used in the rust bindings)
+
+Can be run with MIRI to check the unsafe C interface of the scanner
+
+`tests.rs` is pulled from the tree sitter cli tester source (and then trimmed down)

--- a/rust-tester/src/main.rs
+++ b/rust-tester/src/main.rs
@@ -1,0 +1,9 @@
+mod tests;
+
+fn main() {
+    let language = tree_sitter_python::language();
+    let corpus_dir = std::path::Path::new("../test/corpus");
+
+    tests::run_tests_at_path(language, &corpus_dir, false, None, false)
+        .expect("failed to run tests")
+}

--- a/rust-tester/src/tests.rs
+++ b/rust-tester/src/tests.rs
@@ -1,0 +1,439 @@
+use ansi_term::Colour;
+use anyhow::{anyhow, Result};
+use difference::{Changeset, Difference};
+use lazy_static::lazy_static;
+use regex::bytes::{Regex as ByteRegex, RegexBuilder as ByteRegexBuilder};
+use regex::Regex;
+use std::fmt::Write as FmtWrite;
+use std::fs;
+use std::io::{self, Write};
+use std::path::{Path, PathBuf};
+use std::str;
+use tree_sitter::{Language, LogType, Parser};
+
+lazy_static! {
+    static ref HEADER_REGEX: ByteRegex =
+        ByteRegexBuilder::new(r"^===+(?P<suffix1>[^=\r\n][^\r\n]*)?\r?\n(?P<test_name>([^=\r\n][^\r\n]*\r?\n)+)===+(?P<suffix2>[^=\r\n][^\r\n]*)?\r?\n")
+            .multi_line(true)
+            .build()
+            .unwrap();
+    static ref DIVIDER_REGEX: ByteRegex = ByteRegexBuilder::new(r"^---+(?P<suffix>[^-\r\n][^\r\n]*)?\r?\n")
+        .multi_line(true)
+        .build()
+        .unwrap();
+    static ref COMMENT_REGEX: Regex = Regex::new(r"(?m)^\s*;.*$").unwrap();
+    static ref WHITESPACE_REGEX: Regex = Regex::new(r"\s+").unwrap();
+    static ref SEXP_FIELD_REGEX: Regex = Regex::new(r" \w+: \(").unwrap();
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum TestEntry {
+    Group {
+        name: String,
+        children: Vec<TestEntry>,
+        file_path: Option<PathBuf>,
+    },
+    Example {
+        name: String,
+        input: Vec<u8>,
+        output: String,
+        has_fields: bool,
+    },
+}
+
+impl Default for TestEntry {
+    fn default() -> Self {
+        TestEntry::Group {
+            name: String::new(),
+            children: Vec::new(),
+            file_path: None,
+        }
+    }
+}
+
+pub fn run_tests_at_path(
+    language: Language,
+    path: &Path,
+    debug: bool,
+    filter: Option<&str>,
+    update: bool,
+) -> Result<()> {
+    let test_entry = parse_tests(path)?;
+    let mut parser = Parser::new();
+    parser.set_language(language)?;
+
+    if debug {
+        parser.set_logger(Some(Box::new(|log_type, message| {
+            if log_type == LogType::Lex {
+                io::stderr().write(b"  ").unwrap();
+            }
+            write!(&mut io::stderr(), "{}\n", message).unwrap();
+        })));
+    }
+
+    let mut failures = Vec::new();
+    let mut corrected_entries = Vec::new();
+    run_tests(
+        &mut parser,
+        test_entry,
+        filter,
+        0,
+        &mut failures,
+        update,
+        &mut corrected_entries,
+    )?;
+
+    if failures.len() > 0 {
+        println!("");
+
+        if update {
+            if failures.len() == 1 {
+                println!("1 update:\n")
+            } else {
+                println!("{} updates:\n", failures.len())
+            }
+
+            for (i, (name, ..)) in failures.iter().enumerate() {
+                println!("  {}. {}", i + 1, name);
+            }
+            Ok(())
+        } else {
+            if failures.len() == 1 {
+                println!("1 failure:")
+            } else {
+                println!("{} failures:", failures.len())
+            }
+
+            print_diff_key();
+            for (i, (name, actual, expected)) in failures.iter().enumerate() {
+                println!("\n  {}. {}:", i + 1, name);
+                let actual = format_sexp_indented(&actual, 2);
+                let expected = format_sexp_indented(&expected, 2);
+                print_diff(&actual, &expected);
+            }
+            Err(anyhow!(""))
+        }
+    } else {
+        Ok(())
+    }
+}
+
+pub fn print_diff_key() {
+    println!(
+        "\n{} / {}",
+        Colour::Green.paint("expected"),
+        Colour::Red.paint("actual")
+    );
+}
+
+pub fn print_diff(actual: &String, expected: &String) {
+    let changeset = Changeset::new(actual, expected, "\n");
+    for diff in &changeset.diffs {
+        match diff {
+            Difference::Same(part) => {
+                print!("{}{}", part, changeset.split);
+            }
+            Difference::Add(part) => {
+                print!("{}{}", Colour::Green.paint(part), changeset.split);
+            }
+            Difference::Rem(part) => {
+                print!("{}{}", Colour::Red.paint(part), changeset.split);
+            }
+        }
+    }
+    println!("");
+}
+
+fn run_tests(
+    parser: &mut Parser,
+    test_entry: TestEntry,
+    filter: Option<&str>,
+    mut indent_level: i32,
+    failures: &mut Vec<(String, String, String)>,
+    update: bool,
+    corrected_entries: &mut Vec<(String, String, String)>,
+) -> Result<()> {
+    match test_entry {
+        TestEntry::Example {
+            name,
+            input,
+            output,
+            has_fields,
+        } => {
+            if let Some(filter) = filter {
+                if !name.contains(filter) {
+                    if update {
+                        let input = String::from_utf8(input).unwrap();
+                        let output = format_sexp(&output);
+                        corrected_entries.push((name, input, output));
+                    }
+                    return Ok(());
+                }
+            }
+            let tree = parser.parse(&input, None).unwrap();
+            let mut actual = tree.root_node().to_sexp();
+            if !has_fields {
+                actual = strip_sexp_fields(actual);
+            }
+            for _ in 0..indent_level {
+                print!("  ");
+            }
+            if actual == output {
+                println!("✓ {}", Colour::Green.paint(&name));
+                if update {
+                    let input = String::from_utf8(input).unwrap();
+                    let output = format_sexp(&output);
+                    corrected_entries.push((name, input, output));
+                }
+            } else {
+                if update {
+                    let input = String::from_utf8(input).unwrap();
+                    let output = format_sexp(&actual);
+                    corrected_entries.push((name.clone(), input, output));
+                    println!("✓ {}", Colour::Blue.paint(&name));
+                } else {
+                    println!("✗ {}", Colour::Red.paint(&name));
+                }
+                failures.push((name, actual, output));
+            }
+        }
+        TestEntry::Group {
+            name,
+            children,
+            file_path,
+        } => {
+            if indent_level > 0 {
+                for _ in 0..indent_level {
+                    print!("  ");
+                }
+                println!("{}:", name);
+            }
+
+            let failure_count = failures.len();
+
+            indent_level += 1;
+            for child in children {
+                run_tests(
+                    parser,
+                    child,
+                    filter,
+                    indent_level,
+                    failures,
+                    update,
+                    corrected_entries,
+                )?;
+            }
+
+            if let Some(file_path) = file_path {
+                if update && failures.len() - failure_count > 0 {
+                    write_tests(&file_path, corrected_entries)?;
+                }
+                corrected_entries.clear();
+            }
+        }
+    }
+    Ok(())
+}
+
+fn format_sexp(sexp: &String) -> String {
+    format_sexp_indented(sexp, 0)
+}
+
+fn format_sexp_indented(sexp: &String, initial_indent_level: u32) -> String {
+    let mut formatted = String::new();
+
+    let mut indent_level = initial_indent_level;
+    let mut has_field = false;
+    let mut s_iter = sexp.split(|c| c == ' ' || c == ')');
+    while let Some(s) = s_iter.next() {
+        if s.is_empty() {
+            // ")"
+            indent_level -= 1;
+            write!(formatted, ")").unwrap();
+        } else if s.starts_with('(') {
+            if has_field {
+                has_field = false;
+            } else {
+                if indent_level > 0 {
+                    writeln!(formatted, "").unwrap();
+                    for _ in 0..indent_level {
+                        write!(formatted, "  ").unwrap();
+                    }
+                }
+                indent_level += 1;
+            }
+
+            // "(node_name"
+            write!(formatted, "{}", s).unwrap();
+
+            // "(MISSING node_name" or "(UNEXPECTED 'x'"
+            if s.starts_with("(MISSING") || s.starts_with("(UNEXPECTED") {
+                let s = s_iter.next().unwrap();
+                write!(formatted, " {}", s).unwrap();
+            }
+        } else if s.ends_with(':') {
+            // "field:"
+            writeln!(formatted, "").unwrap();
+            for _ in 0..indent_level {
+                write!(formatted, "  ").unwrap();
+            }
+            write!(formatted, "{} ", s).unwrap();
+            has_field = true;
+            indent_level += 1;
+        }
+    }
+
+    formatted
+}
+
+fn write_tests(file_path: &Path, corrected_entries: &Vec<(String, String, String)>) -> Result<()> {
+    let mut buffer = fs::File::create(file_path)?;
+    write_tests_to_buffer(&mut buffer, corrected_entries)
+}
+
+fn write_tests_to_buffer(
+    buffer: &mut impl Write,
+    corrected_entries: &Vec<(String, String, String)>,
+) -> Result<()> {
+    for (i, (name, input, output)) in corrected_entries.iter().enumerate() {
+        if i > 0 {
+            write!(buffer, "\n")?;
+        }
+        write!(
+            buffer,
+            "{}\n{}\n{}\n{}\n{}\n\n{}\n",
+            "=".repeat(80),
+            name,
+            "=".repeat(80),
+            input,
+            "-".repeat(80),
+            output.trim()
+        )?;
+    }
+    Ok(())
+}
+
+pub fn parse_tests(path: &Path) -> io::Result<TestEntry> {
+    let name = path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("")
+        .to_string();
+    if path.is_dir() {
+        let mut children = Vec::new();
+        for entry in fs::read_dir(path)? {
+            let entry = entry?;
+            let hidden = entry.file_name().to_str().unwrap_or("").starts_with(".");
+            if !hidden {
+                children.push(parse_tests(&entry.path())?);
+            }
+        }
+        Ok(TestEntry::Group {
+            name,
+            children,
+            file_path: None,
+        })
+    } else {
+        let content = fs::read_to_string(path)?;
+        Ok(parse_test_content(name, content, Some(path.to_path_buf())))
+    }
+}
+
+pub fn strip_sexp_fields(sexp: String) -> String {
+    SEXP_FIELD_REGEX.replace_all(&sexp, " (").to_string()
+}
+
+fn parse_test_content(name: String, content: String, file_path: Option<PathBuf>) -> TestEntry {
+    let mut children = Vec::new();
+    let bytes = content.as_bytes();
+    let mut prev_name = String::new();
+    let mut prev_header_end = 0;
+
+    // Find the first test header in the file, and determine if it has a
+    // custom suffix. If so, then this suffix will be used to identify
+    // all subsequent headers and divider lines in the file.
+    let first_suffix = HEADER_REGEX
+        .captures(bytes)
+        .and_then(|c| c.name("suffix1"))
+        .map(|m| String::from_utf8_lossy(m.as_bytes()));
+
+    // Find all of the `===` test headers, which contain the test names.
+    // Ignore any matches whose suffix does not match the first header
+    // suffix in the file.
+    let header_matches = HEADER_REGEX.captures_iter(&bytes).filter_map(|c| {
+        let suffix1 = c
+            .name("suffix1")
+            .map(|m| String::from_utf8_lossy(m.as_bytes()));
+        let suffix2 = c
+            .name("suffix2")
+            .map(|m| String::from_utf8_lossy(m.as_bytes()));
+        if suffix1 == first_suffix && suffix2 == first_suffix {
+            let header_range = c.get(0).unwrap().range();
+            let test_name = c
+                .name("test_name")
+                .map(|c| String::from_utf8_lossy(c.as_bytes()).trim_end().to_string());
+            Some((header_range, test_name))
+        } else {
+            None
+        }
+    });
+
+    for (header_range, test_name) in header_matches.chain(Some((bytes.len()..bytes.len(), None))) {
+        // Find the longest line of dashes following each test description. That line
+        // separates the input from the expected output. Ignore any matches whose suffix
+        // does not match the first suffix in the file.
+        if prev_header_end > 0 {
+            let divider_range = DIVIDER_REGEX
+                .captures_iter(&bytes[prev_header_end..header_range.start])
+                .filter_map(|m| {
+                    let suffix = m
+                        .name("suffix")
+                        .map(|m| String::from_utf8_lossy(m.as_bytes()));
+                    if suffix == first_suffix {
+                        let range = m.get(0).unwrap().range();
+                        Some((prev_header_end + range.start)..(prev_header_end + range.end))
+                    } else {
+                        None
+                    }
+                })
+                .max_by_key(|range| range.len());
+
+            if let Some(divider_range) = divider_range {
+                if let Ok(output) = str::from_utf8(&bytes[divider_range.end..header_range.start]) {
+                    let mut input = bytes[prev_header_end..divider_range.start].to_vec();
+
+                    // Remove trailing newline from the input.
+                    input.pop();
+                    if input.last() == Some(&b'\r') {
+                        input.pop();
+                    }
+
+                    // Remove all comments
+                    let output = COMMENT_REGEX.replace_all(output, "").to_string();
+
+                    // Normalize the whitespace in the expected output.
+                    let output = WHITESPACE_REGEX.replace_all(output.trim(), " ");
+                    let output = output.replace(" )", ")");
+
+                    // Identify if the expected output has fields indicated. If not, then
+                    // fields will not be checked.
+                    let has_fields = SEXP_FIELD_REGEX.is_match(&output);
+
+                    children.push(TestEntry::Example {
+                        name: prev_name,
+                        input,
+                        output,
+                        has_fields,
+                    });
+                }
+            }
+        }
+        prev_name = test_name.unwrap_or(String::new());
+        prev_header_end = header_range.end;
+    }
+    TestEntry::Group {
+        name,
+        children,
+        file_path,
+    }
+}


### PR DESCRIPTION
- Scanner file ported to Rust for Rust bindings (to remove C++ dependency)
- "wasm" cargo feature to switch to tree-sitter-c2rust (to fix the C/Rust wasm incompatibility)
- rust-tester to test the scanner against the corpus tests

currently a proof of concept draft. opened because of a discussion on the discord.