### PR TITLE
Include <stdint.h> for e.g. UINT16_MAX etc.

### DIFF
--- a/src/scanner.cc
+++ b/src/scanner.cc
@@ -4,6 +4,8 @@
 #include <cstring>
 #include <cassert>
 #include <stdio.h>
+#include <stdint.h>
+
 namespace {
 
 using std::vector;


### PR DESCRIPTION
This is required at least on NetBSD, and should in theory not hurt on other platforms, so is not done conditionally.