### PR TITLE
fix: handle error recovery better for dedents in case a string start is possible

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -327,8 +327,13 @@ bool tree_sitter_python_external_scanner_scan(void *payload, TSLexer *lexer,
                 return true;
             }
 
+            bool next_tok_is_string_start = lexer->lookahead == '\"' ||
+                                            lexer->lookahead == '\'' ||
+                                            lexer->lookahead == '`';
+
             if ((valid_symbols[DEDENT] ||
-                 (!valid_symbols[NEWLINE] && !valid_symbols[STRING_START] &&
+                 (!valid_symbols[NEWLINE] &&
+                  !(valid_symbols[STRING_START] && next_tok_is_string_start) &&
                   !within_brackets)) &&
                 indent_length < current_indent_length &&
 


### PR DESCRIPTION
I noticed this slight regression when running the tests in tree-sitter core - @maxbrunsfeld

This won't handle error recovery well for f-strings I think - which is what the inclusion of not dedenting in case string_start was valid was for anyways (they can be dedented and not count as a dedent)..