### PR TITLE
Switch from static_assert to _Static_assert

### DIFF
--- a/src/scanner.c
+++ b/src/scanner.c
@@ -466,7 +466,7 @@ void tree_sitter_python_external_scanner_deserialize(void *payload,
 
 void *tree_sitter_python_external_scanner_create() {
 #if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 201112L)
-    static_assert(sizeof(Delimiter) == sizeof(char), "");
+    _Static_assert(sizeof(Delimiter) == sizeof(char), "");
 #else
     assert(sizeof(Delimiter) == sizeof(char));
 #endif


### PR DESCRIPTION
According to https://en.cppreference.com/w/c/language/_Static_assert in C11 one should use `_Static_assert`, not static_assert. `static_assert` is only valid in C++.

Can a new release be made after this is merged. This is preventing me from using the rust bindings.