### PR TITLE
WIP: Remove redundant indentation check of comment

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[scanner.c]
+indent_style = space
+indent_size = 4


### PR DESCRIPTION
This handles the following case missed by #242 (was still O(n^2) in number of comment lines since DEDENT is valid to lookahead to on every line)
```python
class Foo:
    def foo():
        print("bar")
    # xxx
    # xxx
    def bar():
        print("foo")
```
([big version](https://gist.github.com/llllvvuu/bc80d4df5f39cc27c13297e1d3a39190))

but it does not handle the following case:

```python
class Foo:
    def foo():
        print("bar")
    # xxx
    # xxx
        print("foo")
```

since no dedent token is ever generated and therefore there is nothing to "cache".

It also does not handle the following case (but #244 does):

```python
class Foo:
    def foo():
        print("bar")
        # xxx
        # xxx
        print("foo")
```