### PR TITLE
perf(scanner)!: store and reuse `next_indent_length`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,3 @@
+[scanner.c]
+indent_size = 4
+indent_style = space

--- a/src/scanner.c
+++ b/src/scanner.c
@@ -158,6 +158,8 @@ typedef struct {
     indent_vec indents;
     delimiter_vec delimiters;
     bool inside_f_string;
+    uint32_t next_indent_byte;
+    uint32_t next_indent_length;
 } Scanner;
 
 static inline void advance(TSLexer *lexer) { lexer->advance(lexer, false); }
@@ -311,19 +313,23 @@ bool tree_sitter_python_external_scanner_scan(void *payload, TSLexer *lexer,
         } else if (lexer->lookahead == '\t') {
             indent_length += 8;
             skip(lexer);
-        } else if (lexer->lookahead == '#' &&
-                   (valid_symbols[INDENT] || valid_symbols[DEDENT] ||
-                    valid_symbols[NEWLINE])) {
+        } else if (lexer->lookahead == '#') {
             // If we haven't found an EOL yet,
             // then this is a comment after an expression:
             //   foo = bar # comment
             // Just return, since we don't want to generate an indent/dedent
             // token.
-            if (!found_end_of_line) {
+            if (!(found_end_of_line &&
+                  (valid_symbols[INDENT] || valid_symbols[DEDENT] ||
+                   valid_symbols[NEWLINE]))) {
                 return false;
             }
             if (first_comment_indent_length == -1) {
                 first_comment_indent_length = (int32_t)indent_length;
+                if (lexer->get_byte(lexer) < scanner->next_indent_byte) {
+                    indent_length = scanner->next_indent_length;
+                    break;
+                }
             }
             while (lexer->lookahead && lexer->lookahead != '\n') {
                 skip(lexer);
@@ -347,6 +353,19 @@ bool tree_sitter_python_external_scanner_scan(void *payload, TSLexer *lexer,
         } else {
             break;
         }
+    }
+
+    if (first_comment_indent_length == -1) {
+        // We only use this cache for comments, so don't create any
+        // extra state changes otherwise:
+        // https://github.com/tree-sitter/tree-sitter-html/issues/23
+        scanner->next_indent_byte = 0;
+        scanner->next_indent_length = 0;
+    } else if (scanner->next_indent_byte == 0) {
+        // Keep the original `next_indent_byte` since that's the
+        // non-short-circuited lookahead.
+        scanner->next_indent_byte = lexer->get_byte(lexer);
+        scanner->next_indent_length = indent_length;
     }
 
     if (found_end_of_line) {
@@ -456,6 +475,10 @@ unsigned tree_sitter_python_external_scanner_serialize(void *payload,
     size_t size = 0;
 
     buffer[size++] = (char)scanner->inside_f_string;
+    *(uint32_t *)(buffer + size) = scanner->next_indent_byte;
+    size += sizeof(uint32_t);
+    *(uint32_t *)(buffer + size) = scanner->next_indent_length;
+    size += sizeof(uint32_t);
 
     size_t delimiter_count = scanner->delimiters.len;
     if (delimiter_count > UINT8_MAX) {
@@ -486,11 +509,18 @@ void tree_sitter_python_external_scanner_deserialize(void *payload,
     VEC_CLEAR(scanner->delimiters);
     VEC_CLEAR(scanner->indents);
     VEC_PUSH(scanner->indents, 0);
+    scanner->inside_f_string = false;
+    scanner->next_indent_byte = 0;
+    scanner->next_indent_length = 0;
 
     if (length > 0) {
         size_t size = 0;
 
         scanner->inside_f_string = (bool)buffer[size++];
+        scanner->next_indent_byte = *(uint32_t *)(buffer + size);
+        size += sizeof(uint32_t);
+        scanner->next_indent_length = *(uint32_t *)(buffer + size);
+        size += sizeof(uint32_t);
 
         size_t delimiter_count = (uint8_t)buffer[size++];
         if (delimiter_count > 0) {

--- a/src/tree_sitter/parser.h
+++ b/src/tree_sitter/parser.h
@@ -44,6 +44,7 @@ struct TSLexer {
   TSSymbol result_symbol;
   void (*advance)(TSLexer *, bool);
   void (*mark_end)(TSLexer *);
+  uint32_t (*get_byte)(TSLexer *);
   uint32_t (*get_column)(TSLexer *);
   bool (*is_at_included_range_start)(const TSLexer *);
   bool (*eof)(const TSLexer *);


### PR DESCRIPTION
Whether an indent/dedent token is generated for a comment depends on whether the indent/dedent is persisted after the comment. This takes O(comment_length) to check. Checking it for every line takes O(comment_length * comment_lines), which is quadratic.

An optimization was made in a901729 which skips this check when there is no possible indent/dedent, such as in the following:
 ```python
 # comment 1...
 # comment 1000
 print("foo")
 ```
However, the check cannot be skipped in the following case:

```python
class Foo:
    def foo():
        print("bar")
    # comment 1...
    # comment 1000
    def bar():
        print("foo")
```
which comes up when commenting out code.

This PR optimizes all cases by storing and re-using the next non-comment indent length and re-using it while still valid (requires `TSLexer.get_byte` from upstream `tree-sitter`).

Sample file: https://gist.github.com/llllvvuu/bc80d4df5f39cc27c13297e1d3a39190

Before:
```
tree-sitter parse ~/test/repro2.py  0.52s user 0.01s system 99% cpu 0.535 total
```

After:
```
.../release/tree-sitter parse   0.01s user 0.01s system 88% cpu 0.023 total
```

Fixes: https://github.com/nvim-treesitter/nvim-treesitter/issues/4839

BREAKING CHANGE: This makes the parser incompatible with the current `tree-sitter` ABI.