### PR TITLE
Highlight decorator name

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -11,6 +11,8 @@
 ; Function calls
 
 (decorator) @function
+(decorator
+  (identifier) @function)
 
 (call
   function: (attribute attribute: (identifier) @function.method))


### PR DESCRIPTION
In this code

```py
@my_decorator
def foo():
  return 1
```

```
module [0, 0] - [3, 0]
  decorated_definition [0, 0] - [2, 10]
    decorator [0, 0] - [0, 13]
      identifier [0, 1] - [0, 13]
    definition: function_definition [1, 0] - [2, 10]
      name: identifier [1, 4] - [1, 7]
      parameters: parameters [1, 7] - [1, 9]
      body: block [2, 2] - [2, 10]
        return_statement [2, 2] - [2, 10]
          integer [2, 9] - [2, 10]
```

with the current rules, only the `@` is highlighted as a `function` in the Zed editor. This change is to make the `my_decorator` part also get highlighted as a `function`.

The reason this special case is needed is because decorators can be expressions, you can write something like this

```py
decorators = [dec_a, dec_b, dec_c]

@(decorators[1])
def foo():
  return 1
```

but the vast majority of the time you're just doing `@my_decorator`.