### PR TITLE
fix: escape the ‘#’ in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ override CFLAGS += -I$(SRC_DIR) -std=c11 -fPIC
 
 # ABI versioning
 SONAME_MAJOR := $(word 1,$(subst ., ,$(VERSION)))
-SONAME_MINOR := $(shell sed -n 's/#define LANGUAGE_VERSION //p' $(PARSER))
+SONAME_MINOR := $(shell sed -n 's/\#define LANGUAGE_VERSION //p' $(PARSER))
 
 # OS-specific bits
 ifeq ($(shell uname),Darwin)


### PR DESCRIPTION
Compile using Makefile emit error:
```shell
Makefile:41: *** unterminated call to function 'shell': missing ')'.  Stop
```

It looks like the '#' and its following content are parsed into a comment. Escape it works good.