### PR TITLE
Add MANIFEST.in so we get a valid sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,6 @@
+include setup.py
+include README.md
+include pyproject.toml
+include LICENSE
+recursive-include src *
+recursive-include bindings/python/tree_sitter_java *


### PR DESCRIPTION
The src/tree_sitter/ directory is not included in the sdist so if we attempt to build from it, we get compilation errors due to missing headers. This fixes the sdist.