### PR TITLE
fix(highlights): match constants with digits and leading underscores

### DIFF
--- a/queries/highlights.scm
+++ b/queries/highlights.scm
@@ -6,7 +6,7 @@
  (#match? @constructor "^[A-Z]"))
 
 ((identifier) @constant
- (#match? @constant "^[A-Z][A-Z_]*$"))
+ (#match? @constant "^_*[A-Z][A-Z_0-9]*$"))
 
 ; Function calls
 

--- a/test/highlight/identifiers.py
+++ b/test/highlight/identifiers.py
@@ -1,0 +1,35 @@
+MAX_SIZE = 100
+# <- constant
+
+TOTAL = 50
+# <- constant
+
+PI = 3.14
+# <- constant
+
+HTTP2 = "h2"
+# <- constant
+
+SHA256 = "sha256"
+# <- constant
+
+MEMBER2 = 2
+# <- constant
+
+A85 = "something"
+# <- constant
+
+_PRIVATE = 1
+# <- constant
+
+__DUNDER = 2
+# <- constant
+
+X = 1
+# <- constant
+
+MyClass = None
+# <- constructor
+
+myVar = None
+# <- variable


### PR DESCRIPTION
The constant highlight regex `^[A-Z][A-Z_]*$` did not allow digits or leading underscores, so identifiers like `HTTP2`, `SHA256`, `_PRIVATE` and `__MAX_RETRIES` were not highlighted as constants despite following [PEP 8 naming conventions](https://peps.python.org/pep-0008/#constants).

Updated the regex to `^_*[A-Z][A-Z_0-9]*$` and added highlight tests for identifier naming conventions.