### PR TITLE
fix: update Swift package to use tree-sitter/swift-tree-sitter correctly

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,11 +3,20 @@
     "pins": [
       {
         "package": "SwiftTreeSitter",
-        "repositoryURL": "https://github.com/ChimeHQ/SwiftTreeSitter",
+        "repositoryURL": "https://github.com/tree-sitter/swift-tree-sitter",
         "state": {
           "branch": null,
-          "revision": "2599e95310b3159641469d8a21baf2d3d200e61f",
-          "version": "0.8.0"
+          "revision": "08ef81eb8620617b55b08868126707ad72bf754f",
+          "version": "0.25.0"
+        }
+      },
+      {
+        "package": "TreeSitter",
+        "repositoryURL": "https://github.com/tree-sitter/tree-sitter",
+        "state": {
+          "branch": null,
+          "revision": "da6fe9beb4f7f67beb75914ca8e0d48ae48d6406",
+          "version": "0.25.10"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,7 @@ let package = Package(
         .library(name: "TreeSitterPython", targets: ["TreeSitterPython"]),
     ],
     dependencies: [
-        .package(name: "SwiftTreeSitter", url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.9.0"),
+        .package(url: "https://github.com/tree-sitter/swift-tree-sitter", from: "0.9.0"),
     ],
     targets: [
         .target(
@@ -31,7 +31,7 @@ let package = Package(
         .testTarget(
             name: "TreeSitterPythonTests",
             dependencies: [
-                "SwiftTreeSitter",
+                .product(name: "SwiftTreeSitter", package: "swift-tree-sitter"),
                 "TreeSitterPython",
             ],
             path: "bindings/swift/TreeSitterPythonTests"


### PR DESCRIPTION
Remove explicit package name and use .product() dependency reference to match the canonical tree-sitter/swift-tree-sitter package.